### PR TITLE
feat: add report-failures action for deployment failure reporting

### DIFF
--- a/CONSOLIDATION_PLAN.md
+++ b/CONSOLIDATION_PLAN.md
@@ -1,0 +1,212 @@
+# Consolidate GitHub Actions into Two Repositories
+
+## Overview
+
+This plan consolidates scattered bcgov GitHub Actions into two centralized repositories:
+
+- **bcgov/actions** (current repo): For non-OpenShift/general actions
+- **bcgov/actions-openshift** (new repo): For OpenShift-specific actions
+
+Each action will live in its own subdirectory within the appropriate repository.
+
+## Repository Structure
+
+### bcgov/actions (General Actions - Current Repo)
+
+```
+actions/
+├── diff-triggers/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── pr-description-add/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── test-and-analyse/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── test-and-analyse-java/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── get-pr/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── builder-ghcr/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── report-failures/  # NEW ACTION
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── README.md
+└── LICENSE
+```
+
+### bcgov/actions-openshift (OpenShift Actions - New Repo)
+
+```
+actions-openshift/
+├── crunchy/
+│   ├── action.yml
+│   ├── README.md
+│   ├── charts/
+│   └── scripts/
+├── oc-runner/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── deployer-openshift/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── postgres/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── deployer-helm/
+│   ├── action.yml
+│   ├── README.md
+│   └── [scripts/]
+├── README.md
+└── LICENSE
+```
+
+## Action Subdirectory Structure
+
+Each action subdirectory follows this pattern:
+
+```
+action-name/
+├── action.yml          # Action metadata (required)
+├── README.md          # Documentation with usage examples
+├── entrypoint.sh      # Main script (if composite action)
+├── scripts/           # Supporting scripts (optional)
+│   └── helper.sh
+├── package.json       # If Node.js action (optional)
+└── dist/              # If compiled action (optional)
+```
+
+**Usage in workflows:**
+
+```yaml
+- uses: bcgov/actions/diff-triggers@v1.0.0
+- uses: bcgov/actions-openshift/crunchy@v1.2.5
+```
+
+## Action Naming Convention
+
+Since actions are in a repo named `actions` or `actions-openshift`, subdirectory names do NOT need the `action-` prefix:
+
+- ✅ `diff-triggers/` (not `action-diff-triggers/`)
+- ✅ `crunchy/` (not `action-crunchy/`)
+- ✅ `report-failures/` (not `action-report-failures/`)
+
+Usage: `bcgov/actions/diff-triggers@v1.0.0`
+
+## Migration Strategy
+
+**Phase 1: Assessment & Setup**
+
+1. Assess each existing action to determine:
+   - Active usage status
+   - Code quality and maintenance state
+   - Dependencies and requirements
+
+2. Create the `bcgov/actions-openshift` repository
+3. Establish repository structure and documentation standards
+
+**Phase 2: Migration with Backwards Compatibility**
+
+1. Migrate each action to its new location in the consolidated repo
+2. Update old action repositories to be thin wrapper actions that:
+   - Call the new consolidated action location
+   - Maintain the same interface/inputs
+   - Add deprecation notices in README
+
+3. This allows gradual migration without breaking existing workflows
+
+**Example wrapper structure:**
+
+```yaml
+# In old repo: bcgov/action-diff-triggers/action.yml
+name: 'Diff Triggers (Deprecated)'
+description: '⚠️ This action has moved to bcgov/actions/diff-triggers'
+runs:
+  using: composite
+  steps:
+    - uses: bcgov/actions/diff-triggers@main
+      with:
+        # Pass through all inputs
+```
+
+**Phase 3: Update Workflows & Deprecation**
+
+1. Create migration guide for teams
+2. Update internal workflows to use new locations
+3. Set deprecation timeline for old repos (e.g., 6 months)
+4. Archive old repos after migration period
+
+## New Action: report-failures
+
+Create `report-failures` in the general actions repository:
+
+**Location:** `bcgov/actions/report-failures/`
+
+**Features:**
+
+- Creates GitHub Issues for deployment failures in test/prod zones
+- Reads CODEOWNERS file to auto-assign issue maintainers
+- Only runs on failure conditions
+- Skips for PR deployments (failures visible in PR checks)
+
+**Inputs:**
+
+- `zone` (required): Environment zone (test/prod)
+- `workflow_run_id` (optional): Override workflow run ID
+- `title_template` (optional): Custom issue title template
+- `body_template` (optional): Custom issue body template
+
+**Outputs:**
+
+- `issue_number`: Created issue number
+- `issue_url`: URL to created issue
+
+## Implementation Steps
+
+1. **Create repository structure** in both repos
+   - Add top-level README explaining the consolidation
+   - Set up directory structure for actions
+   - Add LICENSE files
+
+2. **Migrate actions incrementally**
+   - Start with most-used or simplest actions
+   - Test each migration thoroughly
+   - Create wrapper actions in old repos
+
+3. **Create new report-failures action**
+   - Extract the job logic from the provided workflow
+   - Convert to reusable composite action
+   - Add proper inputs/outputs
+   - Write documentation and examples
+
+4. **Create migration script**
+   - Script to help teams update their workflows
+   - Search and replace old action references with new ones
+
+5. **Documentation & Communication**
+   - Create migration guide
+   - Update all action READMEs
+   - Communicate changes to teams
+
+## Decisions Made
+
+1. **Repository naming**: Use `bcgov/actions` (current repo) for general actions, create new `bcgov/actions-openshift` for OpenShift actions
+2. **Versioning strategy**: GitHub releases and tags (semantic versioning)
+3. **Migration script**: Yes, create a script to help teams update their workflows
+4. **Deprecation timeline**: Not set yet - to be determined based on migration progress
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # actions
-Consolidated repo for bcgov-specific actions.  Please feel free to contribute!
+
+Consolidated repo for bcgov-specific GitHub Actions. Please feel free to contribute!
+
+## Available Actions
+
+### General Actions
+
+- **[report-failures](report-failures/)** - Creates GitHub Issues for deployment failures in test/prod zones with auto-assignment from CODEOWNERS
+
+## Usage
+
+Actions in this repository can be used in your workflows like this:
+
+```yaml
+- uses: bcgov/actions/report-failures@main
+  with:
+    zone: test
+```
+
+## Contributing
+
+Please feel free to contribute! When adding new actions:
+
+1. Create a new directory with the action name (no `action-` prefix needed)
+2. Include `action.yml` with proper metadata
+3. Add a comprehensive `README.md` with usage examples
+4. Follow the existing action structure

--- a/report-failures/README.md
+++ b/report-failures/README.md
@@ -1,0 +1,161 @@
+# report-failures
+
+Creates GitHub Issues for deployment failures in test/prod zones with automatic assignment from CODEOWNERS file.
+
+## Features
+
+- Automatically creates GitHub Issues when deployments fail in test/prod environments
+- Reads CODEOWNERS file to auto-assign issue maintainers
+- Only runs on failure conditions (use with `if: failure()`)
+- Skips for PR deployments (failures are visible in PR checks)
+- Handles permission issues gracefully (mentions users if assignment fails)
+
+## Usage
+
+### Basic Usage
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy
+        run: ./deploy.sh
+
+  report-failures:
+    name: Failure Reporting
+    if: failure() && (inputs.zone == 'test' || inputs.zone == 'prod')
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Report Deployment Failure
+        uses: bcgov/actions/report-failures@main
+        with:
+          zone: ${{ inputs.zone }}
+```
+
+### With Custom Templates
+
+```yaml
+- name: Report Deployment Failure
+  uses: bcgov/actions/report-failures@main
+  with:
+    zone: prod
+    title_template: "🚨 Production Deployment Failed - {zone}"
+    body_template: |
+      Deployment to **{zone}** has failed.
+      
+      [View workflow run]({workflow_url})
+      
+      Please investigate immediately.
+```
+
+### Accessing Outputs
+
+```yaml
+- name: Report Deployment Failure
+  id: report
+  uses: bcgov/actions/report-failures@main
+  with:
+    zone: test
+
+- name: Use Issue Info
+  run: |
+    echo "Issue #${{ steps.report.outputs.issue_number }} created"
+    echo "Issue URL: ${{ steps.report.outputs.issue_url }}"
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `zone` | Environment zone (test/prod) | Yes | - |
+| `workflow_run_id` | Override workflow run ID (defaults to current run) | No | Current run ID |
+| `title_template` | Custom issue title template. Use `{zone}` placeholder | No | `ci(deploy): deployment failed in {zone}` |
+| `body_template` | Custom issue body template. Use `{zone}` and `{workflow_url}` placeholders | No | Default message with workflow link |
+| `codeowners_path` | Override CODEOWNERS file path (auto-detected if not provided) | No | Auto-detected |
+
+## Outputs
+
+| Output | Description |
+|-------|-------------|
+| `issue_number` | Created issue number |
+| `issue_url` | URL to created issue |
+
+## CODEOWNERS Detection
+
+The action automatically searches for CODEOWNERS files in the following locations (in order):
+1. Repository root
+2. `.github/` directory
+3. `docs/` directory
+
+The search is case-insensitive, so it will find files named `CODEOWNERS`, `codeowners`, `CodeOwners`, etc.
+
+## Assignment Logic
+
+- Extracts all usernames from CODEOWNERS file (ignores path patterns)
+- Filters out team references (teams cannot be assigned to issues)
+- Limits to 10 assignees (GitHub API limit)
+- If assignment fails due to permissions, mentions users in issue body instead
+
+## Permissions
+
+This action requires the following permissions:
+
+```yaml
+permissions:
+  issues: write  # To create issues
+  contents: read # To read CODEOWNERS file
+```
+
+## Examples
+
+### Full Deployment Workflow
+
+```yaml
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      zone:
+        description: 'Deployment zone'
+        required: true
+        type: choice
+        options:
+          - test
+          - prod
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy
+        run: ./deploy.sh
+
+  report-failures:
+    name: Failure Reporting
+    if: failure() && (github.event.inputs.zone == 'test' || github.event.inputs.zone == 'prod')
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Report Deployment Failure
+        uses: bcgov/actions/report-failures@main
+        with:
+          zone: ${{ github.event.inputs.zone }}
+```
+
+## Notes
+
+- This action should only run on failure conditions (use `if: failure()`)
+- It's designed for test/prod deployments, not PR deployments
+- The action will gracefully handle missing CODEOWNERS files
+- Issue creation errors will fail the step (to surface deployment issues)
+

--- a/report-failures/action.yml
+++ b/report-failures/action.yml
@@ -1,0 +1,152 @@
+name: 'Report Failures'
+description: 'Creates GitHub Issues for deployment failures in test/prod zones with auto-assignment from CODEOWNERS'
+inputs:
+  zone:
+    description: 'Environment zone (test/prod)'
+    required: true
+  workflow_run_id:
+    description: 'Override workflow run ID (defaults to current run)'
+    required: false
+  title_template:
+    description: 'Custom issue title template (default: "ci(deploy): deployment failed in {zone}")'
+    required: false
+  body_template:
+    description: 'Custom issue body template (default includes workflow URL)'
+    required: false
+  codeowners_path:
+    description: 'Override CODEOWNERS file path (auto-detected if not provided)'
+    required: false
+outputs:
+  issue_number:
+    description: 'Created issue number'
+  issue_url:
+    description: 'URL to created issue'
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Find CODEOWNERS file
+      id: find-codeowners
+      shell: bash
+      run: |
+        CODEOWNERS_PATH="${{ inputs.codeowners_path }}"
+        
+        # If path provided, use it; otherwise search
+        if [ -z "$CODEOWNERS_PATH" ]; then
+          # Check root first
+          CODEOWNERS_PATH=$(find . -maxdepth 1 -type f -iname "codeowners*" -not -path "*/\.git/*" 2>/dev/null | head -1)
+          # Then .github/
+          if [ -z "$CODEOWNERS_PATH" ]; then
+            CODEOWNERS_PATH=$(find .github -maxdepth 1 -type f -iname "codeowners*" 2>/dev/null | head -1)
+          fi
+          # Finally docs/
+          if [ -z "$CODEOWNERS_PATH" ]; then
+            CODEOWNERS_PATH=$(find docs -maxdepth 1 -type f -iname "codeowners*" 2>/dev/null | head -1)
+          fi
+        fi
+        
+        if [ -n "$CODEOWNERS_PATH" ]; then
+          echo "path=$CODEOWNERS_PATH" >> $GITHUB_OUTPUT
+          echo "Found CODEOWNERS at: $CODEOWNERS_PATH"
+        else
+          echo "No CODEOWNERS file found"
+        fi
+
+    - name: Report Results
+      id: report
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const fs = require('fs');
+          const zone = '${{ inputs.zone }}';
+          const workflowRunId = '${{ inputs.workflow_run_id }}' || context.runId;
+          const workflowUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${workflowRunId}`;
+          
+          // Use custom templates or defaults
+          const titleTemplate = '${{ inputs.title_template }}' || `ci(deploy): deployment failed in ${zone}`;
+          const bodyTemplate = '${{ inputs.body_template }}' || `❌ Deployment to **${zone}** zone failed.\n\n[View workflow run](${workflowUrl})`;
+          
+          const title = titleTemplate.replace(/{zone}/g, zone);
+          const body = bodyTemplate.replace(/{zone}/g, zone).replace(/{workflow_url}/g, workflowUrl);
+
+          // Read CODEOWNERS file to get assignees
+          let assignees = [];
+          const codeownersPath = '${{ steps.find-codeowners.outputs.path }}'.trim();
+
+          if (codeownersPath) {
+            try {
+              const codeownersContent = fs.readFileSync(codeownersPath, 'utf8');
+              // Filter out comment lines (lines starting with #) and empty lines
+              const lines = codeownersContent.split('\n')
+                .map(line => line.trim())
+                .filter(line => line && !line.startsWith('#'));
+              
+              // Extract usernames from CODEOWNERS (format: * @username or path @username)
+              // Match both users (@username) and teams (@org/team-name)
+              // GitHub usernames must start/end with alphanumeric, can contain hyphens/underscores in middle
+              // NOTE: This intentionally extracts all usernames across all lines, regardless of path patterns.
+              // This ensures deployment failures are visible to all repository maintainers, not just path-specific owners.
+              const usernameMatches = lines.join('\n').match(/@([a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?(?:\/[a-zA-Z0-9](?:[a-zA-Z0-9_-]*[a-zA-Z0-9])?)?)/g);
+              if (usernameMatches) {
+                // Remove '@', filter out team references (those containing '/')
+                // Teams cannot be assigned to issues, only individual users
+                assignees = [...new Set(usernameMatches
+                  .map(m => m.substring(1))
+                  .filter(name => !name.includes('/'))
+                )];
+              }
+            } catch (error) {
+              console.log(`Could not read or parse CODEOWNERS: ${error.message}`);
+            }
+          } else {
+            console.log('No CODEOWNERS file found - issue will be created without assignees');
+          }
+
+          // GitHub Issues API limits assignees to 10 per issue
+          const maxAssignees = 10;
+          const assigneesToUse = assignees.slice(0, maxAssignees);
+          if (assignees.length > maxAssignees) {
+            console.log(`Warning: ${assignees.length} assignees found, limiting to first ${maxAssignees}`);
+          }
+
+          try {
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: body,
+              assignees: assigneesToUse
+            });
+            console.log(`Created issue #${issue.data.number} for deployment failure${assigneesToUse.length > 0 ? ` (assigned to: ${assigneesToUse.join(', ')})` : ''}`);
+            core.setOutput('issue_number', issue.data.number);
+            core.setOutput('issue_url', issue.data.html_url);
+          } catch (error) {
+            // If assignment fails due to permissions, retry without assignees but mention them
+            if (error.status === 422 || (error.response && error.response.status === 422)) {
+              const bodyWithMentions = `${body}\n\ncc: ${assigneesToUse.map(u => `@${u}`).join(' ')}`;
+              try {
+                const issue = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: title,
+                  body: bodyWithMentions
+                });
+                console.log(`Created issue #${issue.data.number} (mentioned: ${assigneesToUse.join(', ')})`);
+                core.setOutput('issue_number', issue.data.number);
+                core.setOutput('issue_url', issue.data.html_url);
+              } catch (retryError) {
+                core.error(`Could not create issue: ${retryError.message}`);
+                throw retryError;
+              }
+            } else {
+              core.error(`Could not create issue: ${error.message}`);
+              throw error;
+            }
+          }
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+


### PR DESCRIPTION
## Summary

Adds a new `report-failures` action that creates GitHub Issues for deployment failures in test/prod zones with automatic assignment from CODEOWNERS file.

## Changes

- Created `report-failures/` action directory with:
  - `action.yml` - Composite action with CODEOWNERS detection and issue creation
  - `README.md` - Comprehensive documentation with examples
- Updated main `README.md` to document the new action
- Added `CONSOLIDATION_PLAN.md` for future reference

## Features

- Automatically finds CODEOWNERS files (root, .github/, docs/)
- Auto-assigns issue maintainers from CODEOWNERS
- Supports custom title and body templates
- Graceful error handling (mentions users if assignment fails)
- Proper outputs for issue number and URL

## Usage

```yaml
- uses: bcgov/actions/report-failures@main
  with:
    zone: test
```

## Testing

Ready for testing. Action structure validated and YAML syntax verified.