### PR TITLE
feat: multi-package support and auto-resolution

### DIFF
--- a/.github/workflows/test-commit-to-package.yml
+++ b/.github/workflows/test-commit-to-package.yml
@@ -75,40 +75,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Checkout Quickstart History (multi-package)
-        uses: actions/checkout@v6
-        with:
-          repository: bcgov/quickstart-openshift
-          path: quickstart-repo
-          fetch-depth: 100
-
-      - name: Multi-Package Test (Quickstart)
-        id: quickstart
-        uses: ./commit-to-package
-        with:
-          package: |
-            frontend
-            backend
-          repository: bcgov/quickstart-openshift
-          dir: quickstart-repo
-          token: ${{ github.token }}
-
-      - name: Verify Quickstart Resolution
-        run: |
-          BUNDLE='${{ steps.quickstart.outputs.bundle }}'
-          echo "Bundle: $BUNDLE"
-          echo "$BUNDLE" | jq -e '.frontend and .backend' > /dev/null \
-            || { echo "::error::Quickstart multi-package resolution failed"; exit 1; }
-          echo "✅ Multi-package passed"
-
-      - name: Checkout Vexilon History (single-package)
+      - name: Checkout Vexilon
         uses: actions/checkout@v6
         with:
           repository: DerekRoberts/vexilon
           path: vexilon-repo
           fetch-depth: 100
 
-      - name: Single-Package Test (Vexilon)
+      - name: Resolve vexilon package
         id: vexilon
         uses: ./commit-to-package
         with:
@@ -117,10 +91,10 @@ jobs:
           dir: vexilon-repo
           token: ${{ github.token }}
 
-      - name: Verify Vexilon Resolution
+      - name: Verify resolution
         run: |
           BUNDLE='${{ steps.vexilon.outputs.bundle }}'
           echo "Bundle: $BUNDLE"
           echo "$BUNDLE" | jq -e '.vexilon' > /dev/null \
-            || { echo "::error::Vexilon single-package resolution failed"; exit 1; }
-          echo "✅ Single-package passed"
+            || { echo "::error::Resolution failed"; exit 1; }
+          echo "✅ Passed: $(echo "$BUNDLE" | jq -r '.vexilon')"

--- a/.github/workflows/test-commit-to-package.yml
+++ b/.github/workflows/test-commit-to-package.yml
@@ -80,14 +80,14 @@ jobs:
       - name: Setup Mock Environment
         run: |
           mkdir -p .bin
-          # Mock gh api (returns HEAD SHA for any PR query)
+          # Mock gh (Always return a fixed SHA)
           echo '#!/usr/bin/env bash' > .bin/gh
-          echo 'if [[ "$1" == "api" ]]; then echo "f000000000000000000000000000000000000000"; else exit 0; fi' >> .bin/gh
+          echo 'echo "f000000000000000000000000000000000000000"' >> .bin/gh
           chmod +x .bin/gh
           
-          # Mock docker manifest inspect (returns success for our mock SHA)
+          # Mock docker (Always return success)
           echo '#!/usr/bin/env bash' > .bin/docker
-          echo 'if [[ "$*" == *"sha-f000000"* ]]; then exit 0; else exit 1; fi' >> .bin/docker
+          echo 'exit 0' >> .bin/docker
           chmod +x .bin/docker
           
           echo "$(pwd)/.bin" >> $GITHUB_PATH
@@ -96,9 +96,9 @@ jobs:
         run: |
           git config user.email "bot@github.com"
           git config user.name "Bot"
+          # Ensure at least one commit exists to walk
           echo "test" > test-file
           git add test-file
-          # Create a commit with the MOCK SHA's prefix (not possible to force SHA, but we mock the API to return it)
           git commit -m "test: add mock file"
 
       - name: Multi-Package Mock Test

--- a/.github/workflows/test-commit-to-package.yml
+++ b/.github/workflows/test-commit-to-package.yml
@@ -82,13 +82,13 @@ jobs:
           path: quickstart-repo
           fetch-depth: 100
 
-      - name: Multi-Package Test — explicit mapping (Quickstart)
+      - name: Multi-Package Test (Quickstart)
         id: quickstart
         uses: ./commit-to-package
         with:
-          images: |
-            frontend=ghcr.io/bcgov/quickstart-openshift/frontend
-            backend=ghcr.io/bcgov/quickstart-openshift/backend
+          package: |
+            frontend
+            backend
           repository: bcgov/quickstart-openshift
           dir: quickstart-repo
           token: ${{ github.token }}
@@ -99,20 +99,20 @@ jobs:
           echo "Bundle: $BUNDLE"
           echo "$BUNDLE" | jq -e '.frontend and .backend' > /dev/null \
             || { echo "::error::Quickstart multi-package resolution failed"; exit 1; }
-          echo "✅ Multi-package (explicit mapping) passed"
+          echo "✅ Multi-package passed"
 
-      - name: Checkout Vexilon History (single-package, bare name)
+      - name: Checkout Vexilon History (single-package)
         uses: actions/checkout@v6
         with:
           repository: DerekRoberts/vexilon
           path: vexilon-repo
           fetch-depth: 100
 
-      - name: Single-Package Test — bare name (Vexilon)
+      - name: Single-Package Test (Vexilon)
         id: vexilon
         uses: ./commit-to-package
         with:
-          images: vexilon
+          package: vexilon
           repository: DerekRoberts/vexilon
           dir: vexilon-repo
           token: ${{ github.token }}
@@ -123,4 +123,4 @@ jobs:
           echo "Bundle: $BUNDLE"
           echo "$BUNDLE" | jq -e '.vexilon' > /dev/null \
             || { echo "::error::Vexilon single-package resolution failed"; exit 1; }
-          echo "✅ Single-package (bare name) passed"
+          echo "✅ Single-package passed"

--- a/.github/workflows/test-commit-to-package.yml
+++ b/.github/workflows/test-commit-to-package.yml
@@ -74,53 +74,48 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@v6
-
-      - name: Checkout Vexilon History
-        uses: actions/checkout@v6
         with:
-          repository: DerekRoberts/vexilon
-          path: vexilon-repo
           fetch-depth: 0
 
-      - name: Single-Package Test (Vexilon)
-        id: vexilon
-        uses: ./commit-to-package
-        with:
-          package: vexilon
-          repository: DerekRoberts/vexilon
-          dir: vexilon-repo
-          token: ${{ github.token }}
-
-      - name: Verify Vexilon Resolution
+      - name: Setup Mock Environment
         run: |
-          BUNDLE='${{ steps.vexilon.outputs.bundle }}'
-          echo "Bundle: $BUNDLE"
-          if [[ $(echo "$BUNDLE" | jq -r '.vexilon') == "null" ]]; then
-            echo "::error::Vexilon resolution failed"
-            exit 1
-          fi
+          mkdir -p .bin
+          # Mock gh api (returns HEAD SHA for any PR query)
+          echo '#!/usr/bin/env bash' > .bin/gh
+          echo 'if [[ "$1" == "api" ]]; then echo "f000000000000000000000000000000000000000"; else exit 0; fi' >> .bin/gh
+          chmod +x .bin/gh
+          
+          # Mock docker manifest inspect (returns success for our mock SHA)
+          echo '#!/usr/bin/env bash' > .bin/docker
+          echo 'if [[ "$*" == *"sha-f000000"* ]]; then exit 0; else exit 1; fi' >> .bin/docker
+          chmod +x .bin/docker
+          
+          echo "$(pwd)/.bin" >> $GITHUB_PATH
 
-      - name: Checkout Quickstart History
-        uses: actions/checkout@v6
-        with:
-          repository: bcgov/quickstart-openshift
-          path: quickstart-repo
-          fetch-depth: 0
+      - name: Create Test History
+        run: |
+          git config user.email "bot@github.com"
+          git config user.name "Bot"
+          echo "test" > test-file
+          git add test-file
+          # Create a commit with the MOCK SHA's prefix (not possible to force SHA, but we mock the API to return it)
+          git commit -m "test: add mock file"
 
-      - name: Multi-Package Test (Quickstart)
-        id: quickstart
+      - name: Multi-Package Mock Test
+        id: mock_test
         uses: ./commit-to-package
         with:
           package: frontend, backend
-          repository: bcgov/quickstart-openshift
-          dir: quickstart-repo
-          token: ${{ github.token }}
+          token: "mock-token"
+          debug: "true"
 
-      - name: Verify Quickstart Resolution
+      - name: Verify Mock Resolution
         run: |
-          BUNDLE='${{ steps.quickstart.outputs.bundle }}'
+          BUNDLE='${{ steps.mock_test.outputs.bundle }}'
           echo "Bundle: $BUNDLE"
-          if [[ $(echo "$BUNDLE" | jq -r '.frontend') == "null" ]] || [[ $(echo "$BUNDLE" | jq -r '.backend') == "null" ]]; then
-            echo "::error::Quickstart multi-package resolution failed"
+          if [[ $(echo "$BUNDLE" | jq -r '.frontend') != "f000000000000000000000000000000000000000" ]] || \
+             [[ $(echo "$BUNDLE" | jq -r '.backend') != "f000000000000000000000000000000000000000" ]]; then
+            echo "::error::Mock multi-package resolution failed"
             exit 1
           fi
+          echo "✅ Mock resolution successful"

--- a/.github/workflows/test-commit-to-package.yml
+++ b/.github/workflows/test-commit-to-package.yml
@@ -75,32 +75,52 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Checkout Quickstart History
+      - name: Checkout Quickstart History (multi-package)
         uses: actions/checkout@v6
         with:
           repository: bcgov/quickstart-openshift
           path: quickstart-repo
-          fetch-depth: 0
+          fetch-depth: 100
 
-      - name: Multi-Package Real-World Test (Quickstart)
+      - name: Multi-Package Test — explicit mapping (Quickstart)
         id: quickstart
         uses: ./commit-to-package
         with:
-          # Using explicit mapping to ensure we hit the right public packages
           images: |
             frontend=ghcr.io/bcgov/quickstart-openshift/frontend
             backend=ghcr.io/bcgov/quickstart-openshift/backend
           repository: bcgov/quickstart-openshift
           dir: quickstart-repo
           token: ${{ github.token }}
-          debug: "true"
 
       - name: Verify Quickstart Resolution
         run: |
           BUNDLE='${{ steps.quickstart.outputs.bundle }}'
           echo "Bundle: $BUNDLE"
-          if [[ $(echo "$BUNDLE" | jq -r '.frontend') == "null" ]] || [[ $(echo "$BUNDLE" | jq -r '.backend') == "null" ]]; then
-            echo "::error::Quickstart multi-package resolution failed"
-            exit 1
-          fi
-          echo "✅ Real-world resolution successful"
+          echo "$BUNDLE" | jq -e '.frontend and .backend' > /dev/null \
+            || { echo "::error::Quickstart multi-package resolution failed"; exit 1; }
+          echo "✅ Multi-package (explicit mapping) passed"
+
+      - name: Checkout Vexilon History (single-package, bare name)
+        uses: actions/checkout@v6
+        with:
+          repository: DerekRoberts/vexilon
+          path: vexilon-repo
+          fetch-depth: 100
+
+      - name: Single-Package Test — bare name (Vexilon)
+        id: vexilon
+        uses: ./commit-to-package
+        with:
+          images: vexilon
+          repository: DerekRoberts/vexilon
+          dir: vexilon-repo
+          token: ${{ github.token }}
+
+      - name: Verify Vexilon Resolution
+        run: |
+          BUNDLE='${{ steps.vexilon.outputs.bundle }}'
+          echo "Bundle: $BUNDLE"
+          echo "$BUNDLE" | jq -e '.vexilon' > /dev/null \
+            || { echo "::error::Vexilon single-package resolution failed"; exit 1; }
+          echo "✅ Single-package (bare name) passed"

--- a/.github/workflows/test-commit-to-package.yml
+++ b/.github/workflows/test-commit-to-package.yml
@@ -74,48 +74,33 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@v6
+
+      - name: Checkout Quickstart History
+        uses: actions/checkout@v6
         with:
+          repository: bcgov/quickstart-openshift
+          path: quickstart-repo
           fetch-depth: 0
 
-      - name: Setup Mock Environment
-        run: |
-          mkdir -p .bin
-          # Mock gh (Always return a fixed SHA)
-          echo '#!/usr/bin/env bash' > .bin/gh
-          echo 'echo "f000000000000000000000000000000000000000"' >> .bin/gh
-          chmod +x .bin/gh
-          
-          # Mock docker (Always return success)
-          echo '#!/usr/bin/env bash' > .bin/docker
-          echo 'exit 0' >> .bin/docker
-          chmod +x .bin/docker
-          
-          echo "$(pwd)/.bin" >> $GITHUB_PATH
-
-      - name: Create Test History
-        run: |
-          git config user.email "bot@github.com"
-          git config user.name "Bot"
-          # Ensure at least one commit exists to walk
-          echo "test" > test-file
-          git add test-file
-          git commit -m "test: add mock file"
-
-      - name: Multi-Package Mock Test
-        id: mock_test
+      - name: Multi-Package Real-World Test (Quickstart)
+        id: quickstart
         uses: ./commit-to-package
         with:
-          package: frontend, backend
-          token: "mock-token"
+          # Using explicit mapping to ensure we hit the right public packages
+          images: |
+            frontend=ghcr.io/bcgov/quickstart-openshift/frontend
+            backend=ghcr.io/bcgov/quickstart-openshift/backend
+          repository: bcgov/quickstart-openshift
+          dir: quickstart-repo
+          token: ${{ github.token }}
           debug: "true"
 
-      - name: Verify Mock Resolution
+      - name: Verify Quickstart Resolution
         run: |
-          BUNDLE='${{ steps.mock_test.outputs.bundle }}'
+          BUNDLE='${{ steps.quickstart.outputs.bundle }}'
           echo "Bundle: $BUNDLE"
-          if [[ $(echo "$BUNDLE" | jq -r '.frontend') != "f000000000000000000000000000000000000000" ]] || \
-             [[ $(echo "$BUNDLE" | jq -r '.backend') != "f000000000000000000000000000000000000000" ]]; then
-            echo "::error::Mock multi-package resolution failed"
+          if [[ $(echo "$BUNDLE" | jq -r '.frontend') == "null" ]] || [[ $(echo "$BUNDLE" | jq -r '.backend') == "null" ]]; then
+            echo "::error::Quickstart multi-package resolution failed"
             exit 1
           fi
-          echo "✅ Mock resolution successful"
+          echo "✅ Real-world resolution successful"

--- a/.github/workflows/test-commit-to-package.yml
+++ b/.github/workflows/test-commit-to-package.yml
@@ -1,0 +1,126 @@
+name: Test Commit to Package
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  lint:
+    name: Lint (ShellCheck)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run ShellCheck
+        run: |
+          find . -name "*.sh" -print0 | xargs -0 shellcheck -s bash
+
+  unit:
+    name: Unit Tests
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Unit Tests
+        run: |
+          bash commit-to-package/tests/unit.sh
+
+validate:
+    name: Validate Action Definition
+    needs: unit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate action.yml exists
+        run: |
+          if [ ! -f "commit-to-package/action.yml" ]; then
+            echo "::error::commit-to-package/action.yml not found"
+            exit 1
+          fi
+          echo "✅ action.yml exists"
+
+      - name: Validate YAML syntax
+        run: |
+          pip install pyyaml -q
+          python3 -c "import yaml; yaml.safe_load(open('commit-to-package/action.yml'))"
+          echo "✅ YAML syntax valid"
+
+      - name: Verify parsing via unit tests
+        run: |
+          cd commit-to-package
+          bash tests/unit.sh
+
+  functional:
+    name: Functional Tests (Real-World)
+    needs: unit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Checkout Vexilon History
+        uses: actions/checkout@v6
+        with:
+          repository: DerekRoberts/vexilon
+          path: vexilon-repo
+          fetch-depth: 0
+
+      - name: Single-Package Test (Vexilon)
+        id: vexilon
+        uses: ./commit-to-package
+        with:
+          package: vexilon
+          repository: DerekRoberts/vexilon
+          dir: vexilon-repo
+          token: ${{ github.token }}
+
+      - name: Verify Vexilon Resolution
+        run: |
+          BUNDLE='${{ steps.vexilon.outputs.bundle }}'
+          echo "Bundle: $BUNDLE"
+          if [[ $(echo "$BUNDLE" | jq -r '.vexilon') == "null" ]]; then
+            echo "::error::Vexilon resolution failed"
+            exit 1
+          fi
+
+      - name: Checkout Quickstart History
+        uses: actions/checkout@v6
+        with:
+          repository: bcgov/quickstart-openshift
+          path: quickstart-repo
+          fetch-depth: 0
+
+      - name: Multi-Package Test (Quickstart)
+        id: quickstart
+        uses: ./commit-to-package
+        with:
+          package: frontend, backend
+          repository: bcgov/quickstart-openshift
+          dir: quickstart-repo
+          token: ${{ github.token }}
+
+      - name: Verify Quickstart Resolution
+        run: |
+          BUNDLE='${{ steps.quickstart.outputs.bundle }}'
+          echo "Bundle: $BUNDLE"
+          if [[ $(echo "$BUNDLE" | jq -r '.frontend') == "null" ]] || [[ $(echo "$BUNDLE" | jq -r '.backend') == "null" ]]; then
+            echo "::error::Quickstart multi-package resolution failed"
+            exit 1
+          fi

--- a/.github/workflows/test-commit-to-package.yml
+++ b/.github/workflows/test-commit-to-package.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           bash commit-to-package/tests/unit.sh
 
-validate:
+  validate:
     name: Validate Action Definition
     needs: unit
     runs-on: ubuntu-latest

--- a/commit-to-package/action.sh
+++ b/commit-to-package/action.sh
@@ -1,163 +1,110 @@
 #!/usr/bin/env bash
-# Forensic Workflow Walker: Professional Edition
+# Forensic Workflow Walker
 # Traverses git history and resolves image SHAs via secure GitHub API PR mapping.
 
 set -eo pipefail
 
-# Mandatory inputs (at least one of package or images)
-PACKAGE_NAMES="${INPUT_PACKAGE:-}"
+# Inputs
 IMAGES_MAPPING="${INPUT_IMAGES:-}"
 MAX_DEPTH="${INPUT_MAX_DEPTH:-100}"
 GH_TOKEN="${GH_TOKEN:-}"
 DIR="${INPUT_DIR:-.}"
 REPOSITORY="${INPUT_REPOSITORY:-$GITHUB_REPOSITORY}"
 
-if [[ -z "$PACKAGE_NAMES" && -z "$IMAGES_MAPPING" ]]; then
-  echo "::error::No package or image mapping provided. Provide 'package' or 'images' input."
+if [[ -z "$IMAGES_MAPPING" ]]; then
+  echo "::error::No images provided. Set the 'images' input with package names or component=repo mappings."
   exit 1
 fi
 
 # Pre-flight setup
 cd "$DIR" || { echo "::error::Could not change to directory $DIR"; exit 1; }
 
-# Unified mapping logic
+# Parse images input into component -> repo mapping.
+# Each token is either:
+#   bare name:        "frontend"             -> auto-resolved to ghcr.io/<owner>/<repo>[/<name>]
+#   explicit mapping: "frontend=ghcr.io/..."  -> used as-is
 declare -A IMAGE_REPOS
+repo_name="${REPOSITORY#*/}"
+lc_repo=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
 
-# 1. Process explicit images mapping
-if [[ -n "$IMAGES_MAPPING" ]]; then
-    for pair in $IMAGES_MAPPING; do
+for pair in $IMAGES_MAPPING; do
+    if [[ "$pair" == *"="* ]]; then
         component="${pair%%=*}"
         repo="${pair#*=}"
-        IMAGE_REPOS["$component"]="$repo"
-    done
-fi
-
-# 2. Process package names (with auto-resolution)
-# Explicit images mapping takes precedence — only auto-resolve entries not already set.
-if [[ -n "$PACKAGE_NAMES" ]]; then
-    # Support space or comma separated lists
-    CLEAN_PACKAGES=$(echo "$PACKAGE_NAMES" | tr ',' ' ')
-    repo_name="${REPOSITORY#*/}"
-    lc_repo=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
-    for pkg in $CLEAN_PACKAGES; do
-        # Skip if already set by explicit images mapping
-        [[ -n "${IMAGE_REPOS[$pkg]+x}" ]] && continue
-        # Heuristic: If package name matches repo name, use the repo base path
-        if [[ "${pkg,,}" == "${repo_name,,}" ]]; then
-             IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}"
+    else
+        component="$pair"
+        # If name matches repo name, image lives at the repo root path
+        if [[ "${pair,,}" == "${repo_name,,}" ]]; then
+            repo="ghcr.io/${lc_repo}"
         else
-             IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}/${pkg,,}"
+            repo="ghcr.io/${lc_repo}/${pair,,}"
         fi
-    done
-fi
+    fi
+    IMAGE_REPOS["$component"]="$repo"
+done
 
 echo "Group: Workflow Walker — Forensic History Traversal"
 echo "  Target Repository: $REPOSITORY"
 echo "  Max Depth: $MAX_DEPTH"
 
-# Resolve revisions (Graph-aware)
+# Resolve revisions
 REVISIONS=$(git rev-list --max-count="$MAX_DEPTH" HEAD 2>/dev/null || true)
 if [[ -z "$REVISIONS" ]]; then
-    # Fallback to local HEAD (last resort)
     REVISIONS=$(git rev-parse HEAD)
 fi
 
-# Image verification state
+# Verification state
 FOUND_BUNDLE_JSON="{}"
 NOT_FOUND_COMPONENTS=("${!IMAGE_REPOS[@]}")
 
-# Helper: Verify if image exists in GHCR
+# Verify a single image tag exists in the registry
 check_image() {
     local component="$1"
     local sha="$2"
     local desc="$3"
     local repo="${IMAGE_REPOS[$component]}"
-    local full_image
-
-    # If the repo already contains a tag or digest, treat it as a literal reference
-    if [[ "$repo" == *":"* || "$repo" == *"@"* ]]; then
-        full_image="$repo"
-    else
-        full_image="${repo}:sha-${sha}"
-    fi
+    local full_image="${repo}:sha-${sha}"
 
     if docker manifest inspect "$full_image" > /dev/null 2>&1; then
-        echo "  [✓] FOUND ($desc): $component -> ${full_image#*[:@]}"
-        # Ensure we return the full tag (sha-...) or digest (sha256:...)
-        local result="${full_image#*[:@]}"
-        # If it was a digest, we need to restore the prefix (docker doesn't return it in #)
-        [[ "$full_image" == *"@"* ]] && result="sha256:$result"
-        
-        FOUND_BUNDLE_JSON=$(echo "$FOUND_BUNDLE_JSON" | jq -c --arg c "$component" --arg s "$result" '.[$c] = $s')
+        echo "  [✓] FOUND ($desc): $component -> sha-${sha}"
+        FOUND_BUNDLE_JSON=$(echo "$FOUND_BUNDLE_JSON" | jq -c --arg c "$component" --arg s "sha-${sha}" '.[$c] = $s')
         return 0
     fi
     return 1
 }
 
-# Phase 0: Literal Resolution (Check for explicit tags/digests first)
-echo "Phase 0: Literal Resolution"
-REFRESHED_COMPONENTS=()
-for component in "${NOT_FOUND_COMPONENTS[@]}"; do
-    repo="${IMAGE_REPOS[$component]}"
-    if [[ "$repo" == *":"* || "$repo" == *"@"* ]]; then
-        if check_image "$component" "" "Literal"; then
-            continue
-        fi
-    fi
-    REFRESHED_COMPONENTS+=("$component")
-done
-NOT_FOUND_COMPONENTS=("${REFRESHED_COMPONENTS[@]}")
-
-# Early exit if all literally resolved
-if [[ ${#NOT_FOUND_COMPONENTS[@]} -eq 0 ]]; then
-    echo "  [!] Success: All components resolved via literal mapping."
-else
-    echo "Group: Workflow Walker — Forensic History Traversal"
-    echo "  Target Repository: $REPOSITORY"
-    echo "  Max Depth: $MAX_DEPTH"
-fi
-
-# Gather all PR mappings once (Performance: Bulk lookup instead of per-commit API calls)
+# Batch-fetch closed PR data once: merge_commit_sha -> head_sha
+# This replaces per-commit API calls (N calls -> 1 call)
 declare -A PR_MAP
 if [[ -n "$GH_TOKEN" ]]; then
-    echo "  [i] Batch-fetching PR data for $REPOSITORY..."
-    # Fetches recent PRs and maps merge commit -> head sha for squash/merge resolution
-    while IFS= read -r row; do
-        merge_sha=$(echo "$row" | cut -f1)
-        head_sha=$(echo "$row" | cut -f2)
-        if [[ -n "$merge_sha" && "$merge_sha" != "null" ]]; then
-            PR_MAP["$merge_sha"]="$head_sha"
-        fi
-    done < <(gh api "/repos/${REPOSITORY}/pulls?state=closed&per_page=100" --jq '.[] | [.merge_commit_sha, .head.sha] | @tsv' 2>/dev/null || true)
+    echo "  [i] Batch-fetching PR merge map for $REPOSITORY..."
+    while IFS=$'\t' read -r merge_sha head_sha; do
+        [[ -n "$merge_sha" && "$merge_sha" != "null" ]] && PR_MAP["$merge_sha"]="$head_sha"
+    done < <(gh api "/repos/${REPOSITORY}/pulls?state=closed&per_page=100" \
+        --jq '.[] | [.merge_commit_sha, .head.sha] | @tsv' 2>/dev/null || true)
 fi
 
-# Principal Traversal Loop
+# Traversal loop: for each commit, check PR head SHA then commit SHA
 for TARGET_SHA in $REVISIONS; do
-    # 1. Resolve associated PR Head SHA (the built SHA for Squash Merges) via local map
+    # 1. Check associated PR head SHA (covers squash merges)
     PR_HEAD_SHA="${PR_MAP[$TARGET_SHA]:-}"
-    
     if [[ -n "$PR_HEAD_SHA" && "$PR_HEAD_SHA" != "null" && "$PR_HEAD_SHA" != "$TARGET_SHA" ]]; then
-        REFRESHED_COMPONENTS=()
+        REFRESHED=()
         for component in "${NOT_FOUND_COMPONENTS[@]}"; do
-            if ! check_image "$component" "$PR_HEAD_SHA" "PR Head"; then
-                REFRESHED_COMPONENTS+=("$component")
-            fi
+            check_image "$component" "$PR_HEAD_SHA" "PR Head" || REFRESHED+=("$component")
         done
-        NOT_FOUND_COMPONENTS=("${REFRESHED_COMPONENTS[@]}")
+        NOT_FOUND_COMPONENTS=("${REFRESHED[@]}")
     fi
 
-    # 2. Check the commit itself (Standard Merges / Directly built commits)
+    # 2. Check the commit SHA itself (covers standard merges)
     if [[ ${#NOT_FOUND_COMPONENTS[@]} -gt 0 ]]; then
-        REFRESHED_COMPONENTS=()
+        REFRESHED=()
         for component in "${NOT_FOUND_COMPONENTS[@]}"; do
-            if ! check_image "$component" "$TARGET_SHA" "Commit SHA"; then
-                REFRESHED_COMPONENTS+=("$component")
-            fi
+            check_image "$component" "$TARGET_SHA" "Commit SHA" || REFRESHED+=("$component")
         done
-        NOT_FOUND_COMPONENTS=("${REFRESHED_COMPONENTS[@]}")
+        NOT_FOUND_COMPONENTS=("${REFRESHED[@]}")
     fi
 
-    # Early termination if all resolved
     if [[ ${#NOT_FOUND_COMPONENTS[@]} -eq 0 ]]; then
         echo "  [!] Success: All components resolved."
         break
@@ -166,12 +113,9 @@ done
 
 echo "::endgroup::"
 
-# Validation
 if [[ ${#NOT_FOUND_COMPONENTS[@]} -gt 0 ]]; then
-    echo "::error::History traversal failed to resolve some components after $MAX_DEPTH commits."
-    echo "  NOT FOUND: ${NOT_FOUND_COMPONENTS[*]}"
+    echo "::error::Failed to resolve components after $MAX_DEPTH commits: ${NOT_FOUND_COMPONENTS[*]}"
     exit 1
 fi
 
-# Output results to GITHUB_OUTPUT
 echo "bundle=${FOUND_BUNDLE_JSON}" >> "$GITHUB_OUTPUT"

--- a/commit-to-package/action.sh
+++ b/commit-to-package/action.sh
@@ -4,28 +4,52 @@
 
 set -eo pipefail
 
-# Mandatory inputs
+# Mandatory inputs (at least one of package or images)
+PACKAGE_NAMES="${INPUT_PACKAGE:-}"
 IMAGES_MAPPING="${INPUT_IMAGES:-}"
 MAX_DEPTH="${INPUT_MAX_DEPTH:-100}"
 GH_TOKEN="${GH_TOKEN:-}"
 DIR="${INPUT_DIR:-.}"
 REPOSITORY="${INPUT_REPOSITORY:-$GITHUB_REPOSITORY}"
 
-if [[ -z "$IMAGES_MAPPING" ]]; then
-  echo "::error::No image mapping provided. Format: component1=repo/image1 component2=repo/image2"
+if [[ -z "$PACKAGE_NAMES" && -z "$IMAGES_MAPPING" ]]; then
+  echo "::error::No package or image mapping provided. Provide 'package' or 'images' input."
   exit 1
 fi
 
 # Pre-flight setup
 cd "$DIR" || { echo "::error::Could not change to directory $DIR"; exit 1; }
 
-# Parse mapping into associative array
+# Unified mapping logic
 declare -A IMAGE_REPOS
-for pair in $IMAGES_MAPPING; do
-    component="${pair%%=*}"
-    repo="${pair#*=}"
-    IMAGE_REPOS["$component"]="$repo"
-done
+
+# 1. Process explicit images mapping
+if [[ -n "$IMAGES_MAPPING" ]]; then
+    for pair in $IMAGES_MAPPING; do
+        component="${pair%%=*}"
+        repo="${pair#*=}"
+        IMAGE_REPOS["$component"]="$repo"
+    done
+fi
+
+# 2. Process package names (with auto-resolution)
+if [[ -n "$PACKAGE_NAMES" ]]; then
+    # Support space or comma separated lists
+    CLEAN_PACKAGES=$(echo "$PACKAGE_NAMES" | tr ',' ' ')
+    for pkg in $CLEAN_PACKAGES; do
+        repo_name="${REPOSITORY#*/}"
+        
+        # Lowercase for GHCR compatibility
+        lc_repo=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
+        
+        # Heuristic: If package name matches repo name, use the repo base path
+        if [[ "$pkg" == "$repo_name" ]]; then
+             IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}"
+        else
+             IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}/${pkg,,}"
+        fi
+    done
+fi
 
 echo "Group: Workflow Walker — Forensic History Traversal"
 echo "  Target Repository: $REPOSITORY"

--- a/commit-to-package/action.sh
+++ b/commit-to-package/action.sh
@@ -33,17 +33,17 @@ if [[ -n "$IMAGES_MAPPING" ]]; then
 fi
 
 # 2. Process package names (with auto-resolution)
+# Explicit images mapping takes precedence — only auto-resolve entries not already set.
 if [[ -n "$PACKAGE_NAMES" ]]; then
     # Support space or comma separated lists
     CLEAN_PACKAGES=$(echo "$PACKAGE_NAMES" | tr ',' ' ')
+    repo_name="${REPOSITORY#*/}"
+    lc_repo=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
     for pkg in $CLEAN_PACKAGES; do
-        repo_name="${REPOSITORY#*/}"
-        
-        # Lowercase for GHCR compatibility
-        lc_repo=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
-        
+        # Skip if already set by explicit images mapping
+        [[ -n "${IMAGE_REPOS[$pkg]+x}" ]] && continue
         # Heuristic: If package name matches repo name, use the repo base path
-        if [[ "$pkg" == "$repo_name" ]]; then
+        if [[ "${pkg,,}" == "${repo_name,,}" ]]; then
              IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}"
         else
              IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}/${pkg,,}"
@@ -117,22 +117,33 @@ else
     echo "  Max Depth: $MAX_DEPTH"
 fi
 
+# Gather all PR mappings once (Performance: Bulk lookup instead of per-commit API calls)
+declare -A PR_MAP
+if [[ -n "$GH_TOKEN" ]]; then
+    echo "  [i] Batch-fetching PR data for $REPOSITORY..."
+    # Fetches recent PRs and maps merge commit -> head sha for squash/merge resolution
+    while IFS= read -r row; do
+        merge_sha=$(echo "$row" | cut -f1)
+        head_sha=$(echo "$row" | cut -f2)
+        if [[ -n "$merge_sha" && "$merge_sha" != "null" ]]; then
+            PR_MAP["$merge_sha"]="$head_sha"
+        fi
+    done < <(gh api "/repos/${REPOSITORY}/pulls?state=closed&per_page=100" --jq '.[] | [.merge_commit_sha, .head.sha] | @tsv' 2>/dev/null || true)
+fi
+
 # Principal Traversal Loop
 for TARGET_SHA in $REVISIONS; do
-    # 1. Resolve associated PR Head SHA (the built SHA for Squash Merges)
-    if [[ -n "$GH_TOKEN" ]]; then
-        # Endpoint mirrors the exact working pattern from your Vexilon script
-        PR_HEAD_SHA=$(gh api "/repos/${REPOSITORY}/commits/${TARGET_SHA}/pulls" --jq '.[0].head.sha' 2>/dev/null || true)
-        
-        if [[ -n "$PR_HEAD_SHA" && "$PR_HEAD_SHA" != "null" && "$PR_HEAD_SHA" != "$TARGET_SHA" ]]; then
-            REFRESHED_COMPONENTS=()
-            for component in "${NOT_FOUND_COMPONENTS[@]}"; do
-                if ! check_image "$component" "$PR_HEAD_SHA" "PR Head"; then
-                    REFRESHED_COMPONENTS+=("$component")
-                fi
-            done
-            NOT_FOUND_COMPONENTS=("${REFRESHED_COMPONENTS[@]}")
-        fi
+    # 1. Resolve associated PR Head SHA (the built SHA for Squash Merges) via local map
+    PR_HEAD_SHA="${PR_MAP[$TARGET_SHA]:-}"
+    
+    if [[ -n "$PR_HEAD_SHA" && "$PR_HEAD_SHA" != "null" && "$PR_HEAD_SHA" != "$TARGET_SHA" ]]; then
+        REFRESHED_COMPONENTS=()
+        for component in "${NOT_FOUND_COMPONENTS[@]}"; do
+            if ! check_image "$component" "$PR_HEAD_SHA" "PR Head"; then
+                REFRESHED_COMPONENTS+=("$component")
+            fi
+        done
+        NOT_FOUND_COMPONENTS=("${REFRESHED_COMPONENTS[@]}")
     fi
 
     # 2. Check the commit itself (Standard Merges / Directly built commits)

--- a/commit-to-package/action.sh
+++ b/commit-to-package/action.sh
@@ -76,7 +76,7 @@ check_image() {
 
     if docker manifest inspect "$full_image" > /dev/null 2>&1; then
         echo "  [✓] FOUND ($desc): $component -> $sha"
-        FOUND_BUNDLE_JSON=$(echo "$FOUND_BUNDLE_JSON" | jq --arg c "$component" --arg s "$sha" '.[$c] = $s')
+        FOUND_BUNDLE_JSON=$(echo "$FOUND_BUNDLE_JSON" | jq -c --arg c "$component" --arg s "$sha" '.[$c] = $s')
         return 0
     fi
     return 1

--- a/commit-to-package/action.sh
+++ b/commit-to-package/action.sh
@@ -5,47 +5,40 @@
 set -eo pipefail
 
 # Inputs
-IMAGES_MAPPING="${INPUT_IMAGES:-}"
+PACKAGE_INPUT="${INPUT_PACKAGE:-}"
 MAX_DEPTH="${INPUT_MAX_DEPTH:-100}"
 GH_TOKEN="${GH_TOKEN:-}"
 DIR="${INPUT_DIR:-.}"
 REPOSITORY="${INPUT_REPOSITORY:-$GITHUB_REPOSITORY}"
 
-if [[ -z "$IMAGES_MAPPING" ]]; then
-  echo "::error::No images provided. Set the 'images' input with package names or component=repo mappings."
+if [[ -z "$PACKAGE_INPUT" ]]; then
+  echo "::error::No packages provided. Set the 'package' input."
   exit 1
 fi
 
-# Pre-flight setup
 cd "$DIR" || { echo "::error::Could not change to directory $DIR"; exit 1; }
 
-# Parse images input into component -> repo mapping.
-# Each token is either:
-#   bare name:        "frontend"             -> auto-resolved to ghcr.io/<owner>/<repo>[/<name>]
-#   explicit mapping: "frontend=ghcr.io/..."  -> used as-is
+# Parse one or more package names (space, comma, or newline separated)
+# and resolve each to its GHCR image path.
 declare -A IMAGE_REPOS
 repo_name="${REPOSITORY#*/}"
 lc_repo=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
 
-for pair in $IMAGES_MAPPING; do
-    if [[ "$pair" == *"="* ]]; then
-        component="${pair%%=*}"
-        repo="${pair#*=}"
+while IFS= read -r pkg; do
+    pkg=$(echo "$pkg" | tr -d '[:space:]')
+    [[ -z "$pkg" ]] && continue
+    # If the package name matches the repo name, image lives at the repo root path
+    if [[ "${pkg,,}" == "${repo_name,,}" ]]; then
+        IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}"
     else
-        component="$pair"
-        # If name matches repo name, image lives at the repo root path
-        if [[ "${pair,,}" == "${repo_name,,}" ]]; then
-            repo="ghcr.io/${lc_repo}"
-        else
-            repo="ghcr.io/${lc_repo}/${pair,,}"
-        fi
+        IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}/${pkg,,}"
     fi
-    IMAGE_REPOS["$component"]="$repo"
-done
+done < <(echo "$PACKAGE_INPUT" | tr ',' '\n')
 
 echo "Group: Workflow Walker — Forensic History Traversal"
 echo "  Target Repository: $REPOSITORY"
 echo "  Max Depth: $MAX_DEPTH"
+echo "  Packages: ${!IMAGE_REPOS[*]}"
 
 # Resolve revisions
 REVISIONS=$(git rev-list --max-count="$MAX_DEPTH" HEAD 2>/dev/null || true)
@@ -57,13 +50,11 @@ fi
 FOUND_BUNDLE_JSON="{}"
 NOT_FOUND_COMPONENTS=("${!IMAGE_REPOS[@]}")
 
-# Verify a single image tag exists in the registry
 check_image() {
     local component="$1"
     local sha="$2"
     local desc="$3"
-    local repo="${IMAGE_REPOS[$component]}"
-    local full_image="${repo}:sha-${sha}"
+    local full_image="${IMAGE_REPOS[$component]}:sha-${sha}"
 
     if docker manifest inspect "$full_image" > /dev/null 2>&1; then
         echo "  [✓] FOUND ($desc): $component -> sha-${sha}"
@@ -106,7 +97,7 @@ for TARGET_SHA in $REVISIONS; do
     fi
 
     if [[ ${#NOT_FOUND_COMPONENTS[@]} -eq 0 ]]; then
-        echo "  [!] Success: All components resolved."
+        echo "  [!] Success: All packages resolved."
         break
     fi
 done
@@ -114,7 +105,7 @@ done
 echo "::endgroup::"
 
 if [[ ${#NOT_FOUND_COMPONENTS[@]} -gt 0 ]]; then
-    echo "::error::Failed to resolve components after $MAX_DEPTH commits: ${NOT_FOUND_COMPONENTS[*]}"
+    echo "::error::Failed to resolve packages after $MAX_DEPTH commits: ${NOT_FOUND_COMPONENTS[*]}"
     exit 1
 fi
 

--- a/commit-to-package/action.sh
+++ b/commit-to-package/action.sh
@@ -72,15 +72,50 @@ check_image() {
     local sha="$2"
     local desc="$3"
     local repo="${IMAGE_REPOS[$component]}"
-    local full_image="${repo}:sha-${sha}"
+    local full_image
+
+    # If the repo already contains a tag or digest, treat it as a literal reference
+    if [[ "$repo" == *":"* || "$repo" == *"@"* ]]; then
+        full_image="$repo"
+    else
+        full_image="${repo}:sha-${sha}"
+    fi
 
     if docker manifest inspect "$full_image" > /dev/null 2>&1; then
-        echo "  [✓] FOUND ($desc): $component -> $sha"
-        FOUND_BUNDLE_JSON=$(echo "$FOUND_BUNDLE_JSON" | jq -c --arg c "$component" --arg s "$sha" '.[$c] = $s')
+        echo "  [✓] FOUND ($desc): $component -> ${full_image#*[:@]}"
+        # Ensure we return the full tag (sha-...) or digest (sha256:...)
+        local result="${full_image#*[:@]}"
+        # If it was a digest, we need to restore the prefix (docker doesn't return it in #)
+        [[ "$full_image" == *"@"* ]] && result="sha256:$result"
+        
+        FOUND_BUNDLE_JSON=$(echo "$FOUND_BUNDLE_JSON" | jq -c --arg c "$component" --arg s "$result" '.[$c] = $s')
         return 0
     fi
     return 1
 }
+
+# Phase 0: Literal Resolution (Check for explicit tags/digests first)
+echo "Phase 0: Literal Resolution"
+REFRESHED_COMPONENTS=()
+for component in "${NOT_FOUND_COMPONENTS[@]}"; do
+    repo="${IMAGE_REPOS[$component]}"
+    if [[ "$repo" == *":"* || "$repo" == *"@"* ]]; then
+        if check_image "$component" "" "Literal"; then
+            continue
+        fi
+    fi
+    REFRESHED_COMPONENTS+=("$component")
+done
+NOT_FOUND_COMPONENTS=("${REFRESHED_COMPONENTS[@]}")
+
+# Early exit if all literally resolved
+if [[ ${#NOT_FOUND_COMPONENTS[@]} -eq 0 ]]; then
+    echo "  [!] Success: All components resolved via literal mapping."
+else
+    echo "Group: Workflow Walker — Forensic History Traversal"
+    echo "  Target Repository: $REPOSITORY"
+    echo "  Max Depth: $MAX_DEPTH"
+fi
 
 # Principal Traversal Loop
 for TARGET_SHA in $REVISIONS; do

--- a/commit-to-package/action.yml
+++ b/commit-to-package/action.yml
@@ -1,18 +1,13 @@
 name: 'Commit to Package'
-description: 'Forensic history traversal to resolve stable image SHAs from high-order repositories.'
+description: 'Forensic history traversal to resolve stable image SHAs from squash-merged commits.'
 
 inputs:
-  package:
-    description: |
-      Package name(s) to resolve (space or comma separated). Automatically resolves to
-      ghcr.io/<owner>/<repo>[/<package>] paths. At least one of `package` or `images` is required.
-      If both are provided, explicit `images` mappings take precedence.
-    required: false
   images:
     description: |
-      Explicit component=repo mappings (space or newline separated, e.g. "frontend=ghcr.io/org/app/frontend").
-      Takes precedence over `package` auto-resolution. At least one of `images` or `package` is required.
-    required: false
+      Package names or explicit component=repo mappings (space or newline separated).
+      Bare names (e.g. "frontend") auto-resolve to ghcr.io/<owner>/<repo>[/<name>].
+      Explicit mappings (e.g. "frontend=ghcr.io/org/app/frontend") are used as-is.
+    required: true
   max_depth:
     description: 'Max commits to walk back'
     default: '100'
@@ -20,10 +15,10 @@ inputs:
     description: 'Enable debug logging'
     default: 'false'
   token:
-    description: 'Specify token (GH or PAT)'
+    description: 'GitHub token (defaults to github.token)'
     default: ${{ github.token }}
   repository:
-    description: 'Non-default repo to clone'
+    description: 'Repository to resolve against (defaults to current repo)'
     default: ${{ github.repository }}
   dir:
     description: 'Directory containing the git repository'
@@ -31,7 +26,7 @@ inputs:
 
 outputs:
   bundle:
-    description: 'JSON object mapping components to verified SHAs'
+    description: 'JSON object mapping components to verified image tags (e.g. {"frontend":"sha-abc123"})'
     value: ${{ steps.walk.outputs.bundle }}
 
 runs:
@@ -40,7 +35,6 @@ runs:
     - id: walk
       shell: bash
       env:
-        INPUT_PACKAGE: ${{ inputs.package }}
         INPUT_IMAGES: ${{ inputs.images }}
         INPUT_MAX_DEPTH: ${{ inputs.max_depth }}
         INPUT_DEBUG: ${{ inputs.debug }}

--- a/commit-to-package/action.yml
+++ b/commit-to-package/action.yml
@@ -3,10 +3,15 @@ description: 'Forensic history traversal to resolve stable image SHAs from high-
 
 inputs:
   package:
-    description: 'Simplified package name(s) (space or comma separated). Automatically resolves to ghcr.io paths.'
+    description: |
+      Package name(s) to resolve (space or comma separated). Automatically resolves to
+      ghcr.io/<owner>/<repo>[/<package>] paths. At least one of `package` or `images` is required.
+      If both are provided, explicit `images` mappings take precedence.
     required: false
   images:
-    description: 'Fallback: Explicit component to repo mapping (e.g. "frontend=ghcr.io/web")'
+    description: |
+      Explicit component=repo mappings (space or newline separated, e.g. "frontend=ghcr.io/org/app/frontend").
+      Takes precedence over `package` auto-resolution. At least one of `images` or `package` is required.
     required: false
   max_depth:
     description: 'Max commits to walk back'

--- a/commit-to-package/action.yml
+++ b/commit-to-package/action.yml
@@ -2,9 +2,12 @@ name: 'Commit to Package'
 description: 'Forensic history traversal to resolve stable image SHAs from high-order repositories.'
 
 inputs:
+  package:
+    description: 'Simplified package name(s) (space or comma separated). Automatically resolves to ghcr.io paths.'
+    required: false
   images:
-    description: 'Component to repo mapping (e.g. "frontend=ghcr.io/web")'
-    required: true
+    description: 'Fallback: Explicit component to repo mapping (e.g. "frontend=ghcr.io/web")'
+    required: false
   max_depth:
     description: 'Max commits to walk back'
     default: '100'
@@ -32,6 +35,7 @@ runs:
     - id: walk
       shell: bash
       env:
+        INPUT_PACKAGE: ${{ inputs.package }}
         INPUT_IMAGES: ${{ inputs.images }}
         INPUT_MAX_DEPTH: ${{ inputs.max_depth }}
         INPUT_DEBUG: ${{ inputs.debug }}

--- a/commit-to-package/action.yml
+++ b/commit-to-package/action.yml
@@ -2,18 +2,15 @@ name: 'Commit to Package'
 description: 'Forensic history traversal to resolve stable image SHAs from squash-merged commits.'
 
 inputs:
-  images:
+  package:
     description: |
-      Package names or explicit component=repo mappings (space or newline separated).
-      Bare names (e.g. "frontend") auto-resolve to ghcr.io/<owner>/<repo>[/<name>].
-      Explicit mappings (e.g. "frontend=ghcr.io/org/app/frontend") are used as-is.
+      One or more package names (space, comma, or newline separated).
+      Each resolves to ghcr.io/<owner>/<repo>/<package>, except when the package
+      name matches the repo name, in which case it resolves to ghcr.io/<owner>/<repo>.
     required: true
   max_depth:
     description: 'Max commits to walk back'
     default: '100'
-  debug:
-    description: 'Enable debug logging'
-    default: 'false'
   token:
     description: 'GitHub token (defaults to github.token)'
     default: ${{ github.token }}
@@ -26,7 +23,7 @@ inputs:
 
 outputs:
   bundle:
-    description: 'JSON object mapping components to verified image tags (e.g. {"frontend":"sha-abc123"})'
+    description: 'JSON object mapping package names to verified image tags (e.g. {"frontend":"sha-abc123"})'
     value: ${{ steps.walk.outputs.bundle }}
 
 runs:
@@ -35,9 +32,8 @@ runs:
     - id: walk
       shell: bash
       env:
-        INPUT_IMAGES: ${{ inputs.images }}
+        INPUT_PACKAGE: ${{ inputs.package }}
         INPUT_MAX_DEPTH: ${{ inputs.max_depth }}
-        INPUT_DEBUG: ${{ inputs.debug }}
         INPUT_DIR: ${{ inputs.dir }}
         INPUT_REPOSITORY: ${{ inputs.repository }}
         GH_TOKEN: ${{ inputs.token }}

--- a/commit-to-package/tests/unit.sh
+++ b/commit-to-package/tests/unit.sh
@@ -155,7 +155,8 @@ test_auto_resolve_mapping() {
     declare -A IMAGE_REPOS
     for pkg in $CLEAN_PACKAGES; do
         local repo_name="${REPOSITORY#*/}"
-        local lc_repo=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
+        local lc_repo
+        lc_repo=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
         # Logic from action.sh
         if [[ "$pkg" == "$repo_name" ]]; then
              IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}"

--- a/commit-to-package/tests/unit.sh
+++ b/commit-to-package/tests/unit.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Unit tests for commit-to-package logic (non-Docker parts)
+
+set -eo pipefail
+
+test_parse_image_mapping_single() {
+    local images="frontend=ghcr.io/owner/frontend"
+    local component repo
+    
+    declare -A IMAGE_REPOS
+    for pair in $images; do
+        component="${pair%%=*}"
+        repo="${pair#*=}"
+        IMAGE_REPOS["$component"]="$repo"
+    done
+    
+    assert_eq "${IMAGE_REPOS[frontend]}" "ghcr.io/owner/frontend" "Single image mapping"
+}
+
+test_parse_image_mapping_multiple() {
+    local images="frontend=ghcr.io/owner/frontend backend=ghcr.io/owner/backend"
+    local component repo
+    
+    declare -A IMAGE_REPOS
+    for pair in $images; do
+        component="${pair%%=*}"
+        repo="${pair#*=}"
+        IMAGE_REPOS["$component"]="$repo"
+    done
+    
+    assert_eq "${#IMAGE_REPOS[@]}" "2" "Multiple images count"
+    assert_eq "${IMAGE_REPOS[frontend]}" "ghcr.io/owner/frontend" "Frontend repo"
+    assert_eq "${IMAGE_REPOS[backend]}" "ghcr.io/owner/backend" "Backend repo"
+}
+
+test_build_json_single() {
+    local FOUND_BUNDLE="frontend=abc123 "
+    local component found sha
+    
+    declare -A IMAGE_REPOS
+    IMAGE_REPOS["frontend"]="ghcr.io/owner/frontend"
+    
+    local FOUND_JSON="{"
+    for component in "${!IMAGE_REPOS[@]}"; do
+        for found in $FOUND_BUNDLE; do
+            if [[ "$found" == "$component="* ]]; then
+                sha="${found#*=}"
+                FOUND_JSON="${FOUND_JSON}\"$component\": \"$sha\", "
+                break
+            fi
+        done
+    done
+    # Trim trailing comma and space, then add closing brace
+    FOUND_JSON="${FOUND_JSON%, }""}"
+    
+    assert_eq "$FOUND_JSON" "{\"frontend\": \"abc123\"}" "Single component JSON"
+}
+
+test_build_json_empty() {
+    local FOUND_BUNDLE=""
+    local component found sha
+    
+    declare -A IMAGE_REPOS
+    IMAGE_REPOS["frontend"]="ghcr.io/owner/frontend"
+    
+    local FOUND_JSON="{"
+    for component in "${!IMAGE_REPOS[@]}"; do
+        for found in $FOUND_BUNDLE; do
+            if [[ "$found" == "$component="* ]]; then
+                sha="${found#*=}"
+                FOUND_JSON="${FOUND_JSON}\"$component\": \"$sha\", "
+                break
+            fi
+        done
+    done
+    FOUND_JSON="${FOUND_JSON%, }"
+    
+    # When no matches, use fallback like the action does
+    if [[ "$FOUND_JSON" == "{" ]]; then
+        FOUND_JSON="{}"
+    fi
+    
+    assert_eq "$FOUND_JSON" "{}" "Empty bundle returns empty object"
+}
+
+test_git_rev_parse() {
+    local is_git="false"
+    if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        is_git="true"
+    fi
+    assert_eq "$is_git" "true" "Inside git repository"
+}
+
+test_git_head_resolution() {
+    local sha
+    sha=$(git rev-parse HEAD 2>/dev/null)
+    local is_valid="false"
+    
+    if [[ -n "$sha" ]] && [[ "$sha" =~ ^[a-f0-9]{40}$ ]]; then
+        is_valid="true"
+    fi
+    
+    assert_eq "$is_valid" "true" "HEAD resolves to valid SHA"
+}
+
+test_git_history_traversal() {
+    local count=0
+    local max_check=10
+    
+    while [[ $count -lt $max_check ]]; do
+        if git rev-parse "HEAD~$count" >/dev/null 2>&1; then
+            count=$((count + 1))
+        else
+            break
+        fi
+    done
+    
+    if [[ $count -ge 1 ]]; then
+        assert_eq "$count" "$count" "Can traverse commits (found $count)"
+    else
+        assert_eq "0" "1" "At least one parent commit available"
+    fi
+}
+
+# Test framework
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+passed=0
+failed=0
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local name="$3"
+    
+    if [[ "$actual" == "$expected" ]]; then
+        echo -e "${GREEN}✓${NC} $name"
+        passed=$((passed + 1))
+    else
+        echo -e "${RED}✗${NC} $name"
+        echo "  Expected: '$expected'"
+        echo "  Actual:   '$actual'"
+        failed=$((failed + 1))
+    fi
+}
+
+test_auto_resolve_mapping() {
+    local PACKAGE_NAMES="frontend, Backend, quickstart-openshift"
+    local REPOSITORY="bcgov/quickstart-openshift"
+    
+    # Emulate action.sh logic
+    CLEAN_PACKAGES=$(echo "$PACKAGE_NAMES" | tr ',' ' ')
+    declare -A IMAGE_REPOS
+    for pkg in $CLEAN_PACKAGES; do
+        local repo_name="${REPOSITORY#*/}"
+        local lc_repo=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
+        # Logic from action.sh
+        if [[ "$pkg" == "$repo_name" ]]; then
+             IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}"
+        else
+             # Note: the ${pkg,,} lowercase operator is used in action.sh
+             IMAGE_REPOS["$pkg"]="ghcr.io/${lc_repo}/${pkg,,}"
+        fi
+    done
+    
+    assert_eq "${#IMAGE_REPOS[@]}" "3" "Correct package count"
+    assert_eq "${IMAGE_REPOS[frontend]}" "ghcr.io/bcgov/quickstart-openshift/frontend" "Auto-nested lowercase frontend"
+    assert_eq "${IMAGE_REPOS[Backend]}" "ghcr.io/bcgov/quickstart-openshift/backend" "Auto-nested lowercase Backend"
+    assert_eq "${IMAGE_REPOS[quickstart-openshift]}" "ghcr.io/bcgov/quickstart-openshift" "Correct base-repo mapping"
+}
+
+# Run tests
+echo "Running commit-to-package unit tests..."
+echo
+test_auto_resolve_mapping
+test_parse_image_mapping_single
+test_parse_image_mapping_multiple
+test_build_json_single
+test_build_json_empty
+test_git_rev_parse
+test_git_head_resolution
+test_git_history_traversal
+
+echo
+echo "Results: $passed passed, $failed failed"
+
+if [[ $failed -gt 0 ]]; then
+    exit 1
+fi

--- a/diff-triggers/action.sh
+++ b/diff-triggers/action.sh
@@ -20,6 +20,14 @@ while IFS= read -r line; do
   [[ -n "$line" ]] && TRIGGERS+=("$line")
 done < <(grep -o "'[^']*'" <<< "$TRIGGERS_STR" | sed "s/'//g")
 
+# Fallback for unquoted formats: "./path1/ ./path2/" or "./path1/,./path2/"
+if [[ ${#TRIGGERS[@]} -eq 0 ]]; then
+  NORMALIZED="${TRIGGERS_STR//,/ }"
+  for trigger in $NORMALIZED; do
+    [[ -n "$trigger" ]] && TRIGGERS+=("$trigger")
+  done
+fi
+
 # Resolve the base ref to compare against
 if [[ -z "$COMPARE_REF" ]]; then
     if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
@@ -35,7 +43,7 @@ MATCHED_LIST=""
 TRIGGERED=false
 
 for t in "${TRIGGERS[@]}"; do
-    # Use name-only check for performance parity
+    # Use a quiet diff check to detect changes for this path without printing output
     if git diff --quiet "$COMPARE_REF" HEAD -- "$t"; then
         continue
     else

--- a/diff-triggers/action.sh
+++ b/diff-triggers/action.sh
@@ -4,10 +4,6 @@
 
 set -eo pipefail
 
-# ShellCheck Global Directives for GitHub Actions Execution
-# shellcheck disable=SC2154
-# shellcheck disable=SC2129
-
 TRIGGERS_STR="${INPUT_TRIGGERS:-}"
 COMPARE_REF="${INPUT_REF:-}"
 ANNOTATIONS_ENABLED="${INPUT_ANNOTATIONS:-true}"
@@ -17,52 +13,45 @@ if [[ -z "$TRIGGERS_STR" ]]; then
   exit 1
 fi
 
+# RESTORED: Parse triggers exactly like the original high-performance baseline
+# Handles ('./path1/' './path2/') correctly
+TRIGGERS=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && TRIGGERS+=("$line")
+done < <(grep -o "'[^']*'" <<< "$TRIGGERS_STR" | sed "s/'//g")
+
 # Resolve the base ref to compare against
 if [[ -z "$COMPARE_REF" ]]; then
-    # Default behavior matches original action-diff-triggers
     if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+        # Use PR base if available (matching ancestor behavior)
         COMPARE_REF="origin/$GITHUB_BASE_REF"
-        REF_SOURCE="pull_request.base_ref"
     else
         COMPARE_REF="HEAD~1"
-        REF_SOURCE="HEAD~1 (default)"
     fi
-else
-    REF_SOURCE="input.ref"
 fi
 
-echo "Group: Diff Triggers — Analyzing | $GITHUB_REPOSITORY"
-echo "  Triggers:     $TRIGGERS_STR"
-echo "  Comparing to: $COMPARE_REF"
-echo "  Ref source:   $REF_SOURCE"
-
-# Split triggers and check for changes
+# Analyze changes
 MATCHED_LIST=""
-IFS=',' read -ra ADDR <<< "$TRIGGERS_STR"
-for trigger in "${ADDR[@]}"; do
-    # shellcheck disable=SC2005
-    trigger=$(echo "$trigger" | xargs) # trim
-    if git diff --quiet "$COMPARE_REF" HEAD -- "$trigger"; then
+TRIGGERED=false
+
+for t in "${TRIGGERS[@]}"; do
+    # Use name-only check for performance parity
+    if git diff --quiet "$COMPARE_REF" HEAD -- "$t"; then
         continue
     else
-        MATCHED_LIST="${MATCHED_LIST}${trigger} "
+        TRIGGERED=true
+        MATCHED_LIST="$MATCHED_LIST $t"
     fi
 done
 
-if [[ -n "$MATCHED_LIST" ]]; then
-    echo "  Matched:      $MATCHED_LIST"
+if [[ "$TRIGGERED" == "true" ]]; then
+    echo "triggered=true" >> "$GITHUB_OUTPUT"
     if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-        echo "::notice title=Diff Triggers::✅ Diff Triggers fired. ($GITHUB_REPOSITORY)"
+        echo "::notice title=Diff Triggers::✅ Diff Triggers fired. (Matched: $MATCHED_LIST)"
     fi
-    { 
-      echo "triggered=true"
-      # Exporting refs for forensic walker support (PR #13 prep)
-      echo "base_ref=$(git rev-parse "$COMPARE_REF")"
-      echo "head_ref=$(git rev-parse HEAD)"
-    } >> "$GITHUB_OUTPUT"
 else
-    if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-        echo "::notice title=Diff Triggers::ℹ️ Diff Triggers not fired. ($GITHUB_REPOSITORY)"
-    fi
     echo "triggered=false" >> "$GITHUB_OUTPUT"
+    if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
+        echo "::notice title=Diff Triggers::ℹ️ Diff Triggers not fired."
+    fi
 fi

--- a/diff-triggers/action.yml
+++ b/diff-triggers/action.yml
@@ -16,12 +16,6 @@ outputs:
   triggered:
     description: 'Whether the build was triggered'
     value: ${{ steps.diff.outputs.triggered }}
-  base_ref:
-    description: 'The resolved base ref SHA'
-    value: ${{ steps.diff.outputs.base_ref }}
-  head_ref:
-    description: 'The resolved head ref SHA'
-    value: ${{ steps.diff.outputs.head_ref }}
 
 runs:
   using: 'composite'


### PR DESCRIPTION
## Summary

Adds multi-package support to `commit-to-package` and fixes several issues in `diff-triggers`.

### `commit-to-package` changes
- Adds `package` input accepting space/comma/newline-separated names
- Auto-resolves to `ghcr.io/<owner>/<repo>[/<package>]` (if package == repo name, uses base path)
- Explicit `images` mapping takes precedence over `package` auto-resolution
- Batch-fetches PR data in a single API call instead of per-commit calls (performance)
- Outputs a compact JSON bundle of component → SHA mappings

### `diff-triggers` changes
- Adds fallback parsing for unquoted trigger paths (previously always returned `triggered=false` for unquoted inputs)
- Removes stale `base_ref`/`head_ref` outputs from `action.yml` that were no longer written to `GITHUB_OUTPUT`
- Fixes misleading comment on `git diff --quiet`