### PR TITLE
feat(image-tracker): auto-checkout with configurable repo, ref, dir

### DIFF
--- a/.github/workflows/test-image-tracker.yml
+++ b/.github/workflows/test-image-tracker.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           package: vexilon
           repository: DerekRoberts/vexilon
+          ref: main
           token: ${{ github.token }}
 
       - name: Verify resolution

--- a/.github/workflows/test-image-tracker.yml
+++ b/.github/workflows/test-image-tracker.yml
@@ -74,7 +74,6 @@ jobs:
         with:
           package: vexilon
           repository: DerekRoberts/vexilon
-          fetch-depth: 100
           token: ${{ github.token }}
 
       - name: Verify resolution

--- a/.github/workflows/test-image-tracker.yml
+++ b/.github/workflows/test-image-tracker.yml
@@ -68,22 +68,13 @@ jobs:
       packages: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Checkout Vexilon
-        uses: actions/checkout@v6
-        with:
-          repository: DerekRoberts/vexilon
-          path: vexilon-repo
-          fetch-depth: 100
-
       - name: Resolve vexilon package
         id: vexilon
         uses: ./image-tracker
         with:
           package: vexilon
           repository: DerekRoberts/vexilon
-          dir: vexilon-repo
+          fetch-depth: 100
           token: ${{ github.token }}
 
       - name: Verify resolution

--- a/.github/workflows/test-image-tracker.yml
+++ b/.github/workflows/test-image-tracker.yml
@@ -68,6 +68,8 @@ jobs:
       packages: read
       pull-requests: read
     steps:
+      - uses: actions/checkout@v6
+
       - name: Resolve vexilon package
         id: vexilon
         uses: ./image-tracker

--- a/.github/workflows/test-image-tracker.yml
+++ b/.github/workflows/test-image-tracker.yml
@@ -88,8 +88,8 @@ jobs:
 
       - name: Verify resolution
         run: |
-          BUNDLE='${{ steps.vexilon.outputs.bundle }}'
-          echo "Bundle: $BUNDLE"
-          echo "$BUNDLE" | jq -e '.vexilon' > /dev/null \
+          PACKAGES='${{ steps.vexilon.outputs.packages }}'
+          echo "Packages: $PACKAGES"
+          echo "$PACKAGES" | jq -e '.vexilon' > /dev/null \
             || { echo "::error::Resolution failed"; exit 1; }
-          echo "✅ Passed: $(echo "$BUNDLE" | jq -r '.vexilon')"
+          echo "✅ Passed: $(echo "$PACKAGES" | jq -r '.vexilon')"

--- a/image-tracker/action.sh
+++ b/image-tracker/action.sh
@@ -58,7 +58,7 @@ if [[ -z "$REVISIONS" ]]; then
 fi
 
 # Verification state
-FOUND_BUNDLE_JSON="{}"
+FOUND_PACKAGES_JSON="{}"
 NOT_FOUND_COMPONENTS=("${!IMAGE_REPOS[@]}")
 
 check_image() {
@@ -69,7 +69,7 @@ check_image() {
 
     if docker manifest inspect "$full_image" > /dev/null 2>&1; then
         echo "  [✓] FOUND ($desc): $component -> sha-${sha}"
-        FOUND_BUNDLE_JSON=$(echo "$FOUND_BUNDLE_JSON" | jq -c --arg c "$component" --arg s "sha-${sha}" '.[$c] = $s')
+        FOUND_PACKAGES_JSON=$(echo "$FOUND_PACKAGES_JSON" | jq -c --arg c "$component" --arg s "sha-${sha}" '.[$c] = $s')
         return 0
     fi
     return 1
@@ -120,4 +120,4 @@ if [[ ${#NOT_FOUND_COMPONENTS[@]} -gt 0 ]]; then
     exit 1
 fi
 
-echo "packages=${FOUND_BUNDLE_JSON}" >> "$GITHUB_OUTPUT"
+echo "packages=${FOUND_PACKAGES_JSON}" >> "$GITHUB_OUTPUT"

--- a/image-tracker/action.sh
+++ b/image-tracker/action.sh
@@ -120,4 +120,4 @@ if [[ ${#NOT_FOUND_COMPONENTS[@]} -gt 0 ]]; then
     exit 1
 fi
 
-echo "bundle=${FOUND_BUNDLE_JSON}" >> "$GITHUB_OUTPUT"
+echo "packages=${FOUND_BUNDLE_JSON}" >> "$GITHUB_OUTPUT"

--- a/image-tracker/action.sh
+++ b/image-tracker/action.sh
@@ -10,7 +10,7 @@ MAX_DEPTH="${INPUT_MAX_DEPTH:-100}"
 GH_TOKEN="${GH_TOKEN:-}"
 DIR="${INPUT_DIR:-.}"
 REPOSITORY="${INPUT_REPOSITORY:-$GITHUB_REPOSITORY}"
-REVISION="${INPUT_REVISION:-HEAD}"
+REVISION="${INPUT_REF:-HEAD}"
 
 if [[ -z "$PACKAGE_INPUT" ]]; then
   echo "::error::No packages provided. Set the 'package' input."

--- a/image-tracker/action.yml
+++ b/image-tracker/action.yml
@@ -24,8 +24,8 @@ inputs:
     description: 'Directory to check out into (defaults to repo name)'
     default: ${{ github.event.repository.name }}
   fetch_depth:
-    description: 'Number of commits to fetch (default: 100)'
-    default: '100'
+    description: 'Number of commits to fetch (default: 0 for full history)'
+    default: '0'
 
 outputs:
   packages:

--- a/image-tracker/action.yml
+++ b/image-tracker/action.yml
@@ -23,6 +23,9 @@ inputs:
   revision:
     description: 'Starting revision to walk back from (Tag, Branch, or SHA)'
     default: 'HEAD'
+  fetch_depth:
+    description: 'Number of commits to fetch (default: 100)'
+    default: '100'
 
 outputs:
   packages:
@@ -32,6 +35,15 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository }}
+        path: ${{ inputs.dir }}
+        ref: ${{ inputs.revision }}
+        fetch-depth: ${{ inputs.fetch_depth }}
+        token: ${{ inputs.token }}
+
     - id: walk
       shell: bash
       env:

--- a/image-tracker/action.yml
+++ b/image-tracker/action.yml
@@ -18,8 +18,8 @@ inputs:
     description: 'Repository to resolve against (defaults to current repo)'
     default: ${{ github.repository }}
   ref:
-    description: 'Git ref (Branch, Tag, or SHA) to check out (defaults to current ref)'
-    default: ${{ github.ref }}
+    description: 'Git ref (Branch, Tag, or SHA) to check out (defaults to default branch)'
+    default: ''
   dir:
     description: 'Directory to check out into (defaults to repo name)'
     default: ${{ github.event.repository.name }}

--- a/image-tracker/action.yml
+++ b/image-tracker/action.yml
@@ -25,9 +25,9 @@ inputs:
     default: 'HEAD'
 
 outputs:
-  bundle:
+  packages:
     description: 'JSON object mapping package names to verified image tags (e.g. {"frontend":"sha-abc123"})'
-    value: ${{ steps.walk.outputs.bundle }}
+    value: ${{ steps.walk.outputs.packages }}
 
 runs:
   using: 'composite'

--- a/image-tracker/action.yml
+++ b/image-tracker/action.yml
@@ -17,12 +17,12 @@ inputs:
   repository:
     description: 'Repository to resolve against (defaults to current repo)'
     default: ${{ github.repository }}
+  ref:
+    description: 'Git ref (Branch, Tag, or SHA) to check out (defaults to current ref)'
+    default: ${{ github.ref }}
   dir:
-    description: 'Directory containing the git repository'
-    default: '.'
-  revision:
-    description: 'Starting revision to walk back from (Tag, Branch, or SHA)'
-    default: 'HEAD'
+    description: 'Directory to check out into (defaults to repo name)'
+    default: ${{ github.event.repository.name }}
   fetch_depth:
     description: 'Number of commits to fetch (default: 100)'
     default: '100'
@@ -40,7 +40,7 @@ runs:
       with:
         repository: ${{ inputs.repository }}
         path: ${{ inputs.dir }}
-        ref: ${{ inputs.revision }}
+        ref: ${{ inputs.ref }}
         fetch-depth: ${{ inputs.fetch_depth }}
         token: ${{ inputs.token }}
 
@@ -51,6 +51,6 @@ runs:
         INPUT_MAX_DEPTH: ${{ inputs.max_depth }}
         INPUT_DIR: ${{ inputs.dir }}
         INPUT_REPOSITORY: ${{ inputs.repository }}
-        INPUT_REVISION: ${{ inputs.revision }}
+        INPUT_REF: ${{ inputs.ref }}
         GH_TOKEN: ${{ inputs.token }}
       run: bash ${{ github.action_path }}/action.sh


### PR DESCRIPTION
## Changes

- Rename output `bundle` → `packages` for clarity
- Add built-in checkout with configurable `fetch_depth`
- Auto-detect `repository`, `ref`, and `dir` from workflow context with override inputs

## Usage

```yaml
- uses: ./image-tracker
  with:
    package: my-pkg
    # All inputs optional - defaults just work
```

Closes #40