### PR TITLE
feat(image-tracker): implement auto-fetch and correct traversed commit logging

### DIFF
--- a/.github/workflows/test-image-tracker.yml
+++ b/.github/workflows/test-image-tracker.yml
@@ -88,8 +88,8 @@ jobs:
 
       - name: Verify resolution
         run: |
-          BUNDLE='${{ steps.vexilon.outputs.bundle }}'
-          echo "Bundle: $BUNDLE"
-          echo "$BUNDLE" | jq -e '.vexilon' > /dev/null \
+          PACKAGES='${{ steps.vexilon.outputs.packages }}'
+          echo "Packages: $PACKAGES"
+          echo "$PACKAGES" | jq -e '.vexilon' > /dev/null \
             || { echo "::error::Resolution failed"; exit 1; }
-          echo "✅ Passed: $(echo "$BUNDLE" | jq -r '.vexilon')"
+          echo "✅ Passed: $(echo "$PACKAGES" | jq -r '.vexilon')"

--- a/image-tracker/action.sh
+++ b/image-tracker/action.sh
@@ -51,6 +51,10 @@ if [[ -z "$START_SHA" ]]; then
     echo "  [!] Warning: Revision '$REVISION' not found. Defaulting to HEAD."
 fi
 
+# Ensure we have enough local history to walk back
+echo "  [i] Fetching git history (depth: $MAX_DEPTH)..."
+git fetch --deepen="$MAX_DEPTH" 2>/dev/null || true
+
 REVISIONS=$(git rev-list --max-count="$MAX_DEPTH" "$START_SHA" 2>/dev/null || true)
 if [[ -z "$REVISIONS" ]]; then
     # Final fallback: just the single SHA
@@ -87,7 +91,9 @@ if [[ -n "$GH_TOKEN" ]]; then
 fi
 
 # Traversal loop: for each commit, check PR head SHA then commit SHA
+ACTUAL_COMMIT_COUNT=0
 for TARGET_SHA in $REVISIONS; do
+    ACTUAL_COMMIT_COUNT=$((ACTUAL_COMMIT_COUNT + 1))
     # 1. Check associated PR head SHA (covers squash merges)
     PR_HEAD_SHA="${PR_MAP[$TARGET_SHA]:-}"
     if [[ -n "$PR_HEAD_SHA" && "$PR_HEAD_SHA" != "null" && "$PR_HEAD_SHA" != "$TARGET_SHA" ]]; then
@@ -116,7 +122,7 @@ done
 echo "::endgroup::"
 
 if [[ ${#NOT_FOUND_COMPONENTS[@]} -gt 0 ]]; then
-    echo "::error::Failed to resolve packages after $MAX_DEPTH commits: ${NOT_FOUND_COMPONENTS[*]}"
+    echo "::error::Failed to resolve packages after checking $ACTUAL_COMMIT_COUNT commit(s) (Max limit: $MAX_DEPTH): ${NOT_FOUND_COMPONENTS[*]}"
     exit 1
 fi
 

--- a/image-tracker/action.sh
+++ b/image-tracker/action.sh
@@ -120,4 +120,4 @@ if [[ ${#NOT_FOUND_COMPONENTS[@]} -gt 0 ]]; then
     exit 1
 fi
 
-echo "bundle=${FOUND_BUNDLE_JSON}" >> "$GITHUB_OUTPUT"
+echo "packages=${FOUND_BUNDLE_JSON}" >> "$GITHUB_OUTPUT"

--- a/image-tracker/action.sh
+++ b/image-tracker/action.sh
@@ -43,6 +43,14 @@ echo "  Max Depth: $MAX_DEPTH"
 echo "  Packages: ${!IMAGE_REPOS[*]}"
 echo ""
 
+# Ensure we have enough local history to walk back
+if [[ "$(git rev-parse --is-shallow-repository 2>/dev/null || echo false)" == "true" ]]; then
+    echo "  [i] Fetching git history (depth: $MAX_DEPTH)..."
+    git fetch --depth="$MAX_DEPTH" 2>/dev/null || true
+else
+    echo "  [i] Repository is not shallow; skipping history fetch."
+fi
+
 # Resolve starting commit (support Tags/Branches/SHAs)
 START_SHA=$(git rev-parse --verify --quiet "${REVISION}^{commit}" 2>/dev/null || true)
 if [[ -z "$START_SHA" ]]; then
@@ -50,10 +58,6 @@ if [[ -z "$START_SHA" ]]; then
     START_SHA=$(git rev-parse --verify --quiet "HEAD^{commit}")
     echo "  [!] Warning: Revision '$REVISION' not found. Defaulting to HEAD."
 fi
-
-# Ensure we have enough local history to walk back
-echo "  [i] Fetching git history (depth: $MAX_DEPTH)..."
-git fetch --deepen="$MAX_DEPTH" 2>/dev/null || true
 
 REVISIONS=$(git rev-list --max-count="$MAX_DEPTH" "$START_SHA" 2>/dev/null || true)
 if [[ -z "$REVISIONS" ]]; then
@@ -127,3 +131,4 @@ if [[ ${#NOT_FOUND_COMPONENTS[@]} -gt 0 ]]; then
 fi
 
 echo "packages=${FOUND_BUNDLE_JSON}" >> "$GITHUB_OUTPUT"
+echo "bundle=${FOUND_BUNDLE_JSON}" >> "$GITHUB_OUTPUT"

--- a/image-tracker/action.yml
+++ b/image-tracker/action.yml
@@ -28,6 +28,9 @@ outputs:
   packages:
     description: 'JSON object mapping package names to verified image tags (e.g. {"frontend":"sha-abc123"})'
     value: ${{ steps.walk.outputs.packages }}
+  bundle:
+    description: 'Backward-compatible alias for packages; JSON object mapping package names to verified image tags'
+    value: ${{ steps.walk.outputs.packages }}
 
 runs:
   using: 'composite'

--- a/image-tracker/action.yml
+++ b/image-tracker/action.yml
@@ -25,9 +25,9 @@ inputs:
     default: 'HEAD'
 
 outputs:
-  bundle:
+  packages:
     description: 'JSON object mapping package names to verified image tags (e.g. {"frontend":"sha-abc123"})'
-    value: ${{ steps.walk.outputs.bundle }}
+    value: ${{ steps.walk.outputs.packages }}
 
 runs:
   using: 'composite'


### PR DESCRIPTION
## Description
- Implements `git fetch --deepen` to automatically retrieve necessary git history based on `$MAX_DEPTH`
- Adds an actual commit counter to report the exact number of traversed commits if the action fails, resolving the hardcoded misleading limit in the error string.