### PR TITLE
feat(image-tracker)!: resolve vanilla sha-<short> tags from metadata-action

### DIFF
--- a/.github/workflows/test-image-tracker.yml
+++ b/.github/workflows/test-image-tracker.yml
@@ -70,26 +70,30 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Checkout Vexilon
+      - name: Checkout Quickstart
         uses: actions/checkout@v6
         with:
-          repository: DerekRoberts/vexilon
-          path: vexilon-repo
+          repository: bcgov/quickstart-openshift
+          path: quickstart-repo
           fetch-depth: 100
 
-      - name: Resolve vexilon package
-        id: vexilon
+      - name: Resolve Quickstart packages
+        id: quickstart
         uses: ./image-tracker
         with:
-          package: vexilon
-          repository: DerekRoberts/vexilon
-          dir: vexilon-repo
+          package: frontend, backend, quickstart-openshift
+          repository: bcgov/quickstart-openshift
+          dir: quickstart-repo
           token: ${{ github.token }}
 
       - name: Verify resolution
         run: |
-          PACKAGES='${{ steps.vexilon.outputs.packages }}'
+          PACKAGES='${{ steps.quickstart.outputs.packages }}'
           echo "Packages: $PACKAGES"
-          echo "$PACKAGES" | jq -e '.vexilon' > /dev/null \
-            || { echo "::error::Resolution failed"; exit 1; }
-          echo "✅ Passed: $(echo "$PACKAGES" | jq -r '.vexilon')"
+          echo "$PACKAGES" | jq -e '.frontend' > /dev/null \
+            || { echo "::error::frontend resolution failed"; exit 1; }
+          echo "$PACKAGES" | jq -e '.backend' > /dev/null \
+            || { echo "::error::backend resolution failed"; exit 1; }
+          echo "$PACKAGES" | jq -e '."quickstart-openshift"' > /dev/null \
+            || { echo "::error::base-repo resolution failed"; exit 1; }
+          echo "✅ Passed: $PACKAGES"

--- a/image-tracker/README.md
+++ b/image-tracker/README.md
@@ -2,17 +2,38 @@
 
 Resolve stable image SHAs from GitHub Container Registry (GHCR) by traversing the git history.
 
+## Requirements
+
+**This action requires images to be published with [`docker/metadata-action`](https://github.com/docker/metadata-action) using its default `type=sha` tag.** That means tags of the form `sha-<7-char-short-sha>` (e.g. `sha-abc1234`). No other tag formats are supported.
+
+A minimal publishing workflow looks like:
+
+````yaml
+- uses: docker/metadata-action@v5
+  id: meta
+  with:
+    images: ghcr.io/${{ github.repository }}
+    # Default `tags:` is sufficient — it emits `type=sha` (short) on every push.
+
+- uses: docker/build-push-action@v6
+  with:
+    push: true
+    tags: ${{ steps.meta.outputs.tags }}
+````
+
+If you publish with any other tag format (full SHA, semver-only, etc.), Image Tracker will not find your images.
+
 ## The Problem
 CI builds often create images on every commit to `main`, but humans (or bots) create **Tags** and **Releases** at a later point in time. Often, the commit that is tagged (e.g., a "version bump" or "merge commit") **is not the commit that actually built the image**. This creates an "Artifact Gap" where the release tag doesn't have a corresponding image in GHCR.
 
 ## The Solution: Forensic Walking
-Image Tracker solves this by taking a starting **Revision** (Tag, Branch, or SHA) and "walking" backwards through its ancestry. It checks each commit for a corresponding `sha-<sha>` image in GHCR until it finds a match for all requested packages.
+Image Tracker solves this by taking a starting **Revision** (Tag, Branch, or SHA) and "walking" backwards through its ancestry. It checks each commit for a corresponding `sha-<short-sha>` image in GHCR until it finds a match for all requested packages.
 
 This ensures you always get the **exact binary state** that leads to a release, even if the release commit itself didn't trigger a build.
 
 ## Usage
 
-```yaml
+````yaml
 - name: Resolve Images
   id: tracker
   uses: bcgov/actions/image-tracker@main
@@ -20,23 +41,25 @@ This ensures you always get the **exact binary state** that leads to a release, 
     package: 'frontend, backend, database'
     revision: 'v1.2.3' # Optional: Walk back from this tag (Defaults to HEAD)
     max_depth: 50      # Optional: How many commits to walk (Defaults to 100)
-```
+````
 
 ## Inputs
 
-| Input | Description | Default |
-|---|---|---|
-| `package` | **Required.** One or more package names (comma separated). | - |
-| `revision` | The Tag, Branch, or SHA to start the walk from. | `HEAD` |
-| `max_depth` | How many commits to traverse before failing. | `100` |
-| `token` | GitHub token for PR metadata lookups (to support squash merges). | `github.token` |
-| `repository` | The repository to resolve against. | `current` |
+| Input        | Description                                                       | Default       |
+| ------------ | ----------------------------------------------------------------- | ------------- |
+| `package`    | **Required.** One or more package names (comma separated).        | -             |
+| `revision`   | The Tag, Branch, or SHA to start the walk from.                   | `HEAD`        |
+| `max_depth`  | How many commits to traverse before failing.                      | `100`         |
+| `token`      | GitHub token for PR metadata lookups (to support squash merges).  | `github.token`|
+| `repository` | The repository to resolve against.                                | current repo  |
+| `dir`        | Directory containing the git repository.                          | `.`           |
 
 ## Outputs
 
-| Output | Description |
-|---|---|
-| `bundle` | A JSON object mapping package names to SHAs: `{"frontend":"sha-abc123"}` |
+| Output     | Description                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------- |
+| `packages` | JSON object mapping package names to resolved short-SHA tags: `{"frontend":"sha-abc1234"}`. |
+| `bundle`   | Alias for `packages` (identical value).                                                     |
 
 ## Internal Logic: PR Mapping
 To support **Squash Merges**, Image Tracker doesn't just check the commit SHA. It also uses the GitHub API to find the **PR Head SHA** associated with any merge commit. It checks the PR's original head commit FIRST, ensuring that squashed artifacts are correctly resolved.

--- a/image-tracker/action.sh
+++ b/image-tracker/action.sh
@@ -73,11 +73,13 @@ check_image() {
     local component="$1"
     local sha="$2"
     local desc="$3"
-    local full_image="${IMAGE_REPOS[$component]}:sha-${sha}"
+    # Match docker/metadata-action's default `type=sha` short-SHA (7 chars) tag format.
+    local short_sha="${sha:0:7}"
+    local full_image="${IMAGE_REPOS[$component]}:sha-${short_sha}"
 
     if docker manifest inspect "$full_image" > /dev/null 2>&1; then
-        echo "  [✓] FOUND ($desc): $component -> sha-${sha}"
-        FOUND_BUNDLE_JSON=$(echo "$FOUND_BUNDLE_JSON" | jq -c --arg c "$component" --arg s "sha-${sha}" '.[$c] = $s')
+        echo "  [✓] FOUND ($desc): $component -> sha-${short_sha}"
+        FOUND_BUNDLE_JSON=$(echo "$FOUND_BUNDLE_JSON" | jq -c --arg c "$component" --arg s "sha-${short_sha}" '.[$c] = $s')
         return 0
     fi
     return 1


### PR DESCRIPTION
## Summary

Switches `image-tracker` from full-SHA tags to the vanilla **7-char short-SHA** (`sha-<short>`) tag format produced by [`docker/metadata-action`](https://github.com/docker/metadata-action)'s default `type=sha` setting. This is the format every standard GHCR publishing workflow produces out of the box.

## Why

Previously the action looked for `sha-<40-char-full-sha>` images, which `docker/metadata-action` does **not** produce by default. That meant the action silently failed for any project using a standard publishing workflow. This aligns the action with the real-world tag format everyone already has.

## Changes

- `image-tracker/action.sh`: use `${sha:0:7}` when probing GHCR manifests (3 lines of logic).
- `image-tracker/README.md`: add a prominent **Requirements** section calling out that `docker/metadata-action` is required, with a minimal publishing example.
- `.github/workflows/test-image-tracker.yml`: switch the functional test target from `DerekRoberts/vexilon` to `bcgov/quickstart-openshift` (exercises multi-package + base-repo cases).

## Breaking change

⚠️ Consumers must publish images with `docker/metadata-action`'s default short-SHA format. Full-SHA-only tags are no longer resolved. There is currently only one consumer (Derek), who has signed off on the break.

## Validation

- `shellcheck -s bash image-tracker/action.sh image-tracker/tests/unit.sh` → clean
- `bash image-tracker/tests/unit.sh` → 18/18 passing
- YAML syntax validated for `action.yml` and `test-image-tracker.yml`
- Functional test will be validated by CI against real GHCR images on `bcgov/quickstart-openshift`

## Supersedes

This PR replaces the tangled work in #40 and #44, both of which will be closed as superseded.

Closes #40
Closes #44