### PR TITLE
fix(inputs): switch optional input to github_token

### DIFF
--- a/.github/workflows/test-notifier.yml
+++ b/.github/workflows/test-notifier.yml
@@ -33,7 +33,7 @@ jobs:
         id: dry_run
         uses: ./workflow-notifier
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           title: "[DRY RUN] Simulating a failure for testing"
           body: "This is a dry run test of the notifier action."
           dry_run: true

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+.tmp/
+

--- a/.tmp/git_test.sh
+++ b/.tmp/git_test.sh
@@ -1,0 +1,4 @@
+echo 'Testing git rev-parse HEAD~1...'
+RESULT=$(git rev-parse HEAD~1 2>/dev/null || echo 'EMPTY')
+echo 'Result: >$RESULT<'
+

--- a/.tmp/git_test.sh
+++ b/.tmp/git_test.sh
@@ -1,4 +1,0 @@
-echo 'Testing git rev-parse HEAD~1...'
-RESULT=$(git rev-parse HEAD~1 2>/dev/null || echo 'EMPTY')
-echo 'Result: >$RESULT<'
-

--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ This will:
 
 ## ✨ Standards & Principles
 
-1. **Standard Inputs**: All actions SHOULD support \`token\` and \`debug\` inputs.
+1. **Standard Inputs**: All actions SHOULD support \`github_token\` and \`debug\` inputs.
 2. **Bash-First**: Prefer **Composite Actions** calling dedicated shell scripts (\`action.sh\`) for simple logic.
 3. **Consistent Branding**: Icons/Colors should reflect purpose (Build = blue, Fail/Alert = red).

--- a/builder-ghcr/README.md
+++ b/builder-ghcr/README.md
@@ -77,7 +77,7 @@ Only GitHub Container Registry (ghcr.io) is supported so far.
     sbom: 'true'
 
     # Specify token (GH or PAT), instead of inheriting one from the calling workflow
-    token: ${{ secrets.GITHUB_TOKEN }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
 
     # Multiline input for secrets to mount.
     # https://docs.docker.com/build/ci/github-actions/secrets/#secret-mounts
@@ -149,7 +149,7 @@ builds:
           ${{ github.sha }}
           latest
         tag_fallback: test
-        token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         triggers: ('frontend/')
 ```
 
@@ -177,7 +177,7 @@ builds:
         tags: ${{ github.event.number }}
         tag_fallback: test
         repository: bcgov/nr-quickstart-typescript
-        token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         triggers: ${{ matrix.triggers }}
 
 ```

--- a/builder-ghcr/action.yml
+++ b/builder-ghcr/action.yml
@@ -42,7 +42,7 @@ inputs:
   repository:
     description: Non-default repo to clone
     default: ${{ github.repository }}
-  token:
+  github_token:
     description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
     default: ${{ github.token }}
   secrets:
@@ -221,7 +221,7 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ inputs.token }}
+        password: ${{ inputs.github_token }}
 
     # If a build is not required, reuse a previous image
     - name: Recycle/retag Previous Images

--- a/get-pr/README.md
+++ b/get-pr/README.md
@@ -7,12 +7,12 @@ Get PR number for merge queues, squash merges, and releases
 ```yaml
 - uses: bcgov/actions/get-pr@v1
   with:
-    token: ${{ secrets.GITHUB_TOKEN }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Inputs
 
 | Name | Description | Default |
 |------|-------------|---------|
-| `token` | GitHub token | `${{ github.token }}` |
+| `github_token` | GitHub token | `${{ github.token }}` |
 | `debug` | Enable debug logging | `false` |

--- a/get-pr/action.yml
+++ b/get-pr/action.yml
@@ -5,7 +5,7 @@ branding:
   color: blue
 
 inputs:
-  token:
+  github_token:
     description: "Specify token (GH or PAT), instead of inheriting one from the calling workflow"
     required: false
     default: "${{ github.token }}"
@@ -26,7 +26,7 @@ runs:
       id: run_script
       shell: bash
       env:
-        INPUT_TOKEN: "${{ inputs.token }}"
+        INPUT_TOKEN: "${{ inputs.github_token }}"
         INPUT_DEBUG: "${{ inputs.debug }}"
         MERGE_GROUP_HEAD_REF: "${{ github.event.merge_group.head_ref }}"
         GITHUB_EVENT_AFTER: "${{ github.event.after }}"

--- a/image-tracker/README.md
+++ b/image-tracker/README.md
@@ -88,7 +88,7 @@ External repository:
 | `revision`   |          | `HEAD`               | Git revision (SHA, branch, or tag) to resolve against.                         |
 | `repository` |          | current repo         | Repository owning the images.                                                  |
 | `dir`        |          | `.`                  | Working directory containing the git repository.                               |
-| `token`      |          | `github.token`       | GitHub token used to mint a GHCR bearer token.                                 |
+| `github_token` |        | `github.token`       | GitHub token used to mint a GHCR bearer token.                                 |
 | `max_tags`   |          | `500`                | Upper bound on tags inspected per package before failing.                      |
 | `max_depth`  |          | `1`                  | Max number of commits back in history to search for an image.                  |
 

--- a/image-tracker/action.yml
+++ b/image-tracker/action.yml
@@ -18,7 +18,7 @@ inputs:
   dir:
     description: 'Working directory containing the git repository.'
     default: '.'
-  token:
+  github_token:
     description: 'GitHub token for GHCR auth (defaults to github.token).'
     default: ${{ github.token }}
   max_tags:
@@ -60,7 +60,7 @@ runs:
         INPUT_REVISION: ${{ inputs.revision }}
         INPUT_REPOSITORY: ${{ inputs.repository }}
         INPUT_DIR: ${{ inputs.dir }}
-        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_TOKEN: ${{ inputs.github_token }}
         INPUT_MAX_TAGS: ${{ inputs.max_tags }}
         INPUT_MAX_DEPTH: ${{ inputs.max_depth }}
       run: bash ${{ github.action_path }}/action.sh

--- a/scaffold.sh
+++ b/scaffold.sh
@@ -45,14 +45,14 @@ $DESCRIPTION
 \`\`\`yaml
 - uses: bcgov/actions/$NAME@v1
   with:
-    token: \${{ secrets.GITHUB_TOKEN }}
+    github_token: \${{ secrets.GITHUB_TOKEN }}
 \`\`\`
 
 ## Inputs
 
 | Name | Description | Default |
 |------|-------------|---------|
-| \`token\` | GitHub token | \`\${{ github.token }}\` |
+| \`github_token\` | GitHub token | \`\${{ github.token }}\` |
 | \`debug\` | Enable debug logging | \`false\` |
 EOF
 

--- a/skeleton/action.yml
+++ b/skeleton/action.yml
@@ -5,7 +5,7 @@ branding:
   color: "blue"
 
 inputs:
-  token:
+  github_token:
     description: "GitHub token (defaults to github.token)"
     default: "${{ github.token }}"
   debug:
@@ -20,7 +20,7 @@ runs:
   steps:
     - shell: bash
       env:
-        INPUT_TOKEN: "${{ inputs.token }}"
+        INPUT_TOKEN: "${{ inputs.github_token }}"
         INPUT_DEBUG: "${{ inputs.debug }}"
       run: |
         "${{ github.action_path }}/action.sh"

--- a/workflow-notifier/action.yml
+++ b/workflow-notifier/action.yml
@@ -5,7 +5,7 @@ branding:
   color: "red"
 
 inputs:
-  token:
+  github_token:
     description: "GitHub token (defaults to github.token)"
     default: "${{ github.token }}"
   debug:
@@ -42,7 +42,7 @@ runs:
       id: run_script
       shell: bash
       env:
-        INPUT_TOKEN: "${{ inputs.token }}"
+        INPUT_TOKEN: "${{ inputs.github_token }}"
         INPUT_DEBUG: "${{ inputs.debug }}"
         INPUT_TITLE: "${{ inputs.title }}"
         INPUT_BODY: "${{ inputs.body }}"


### PR DESCRIPTION
This PR renames the 'token' input parameter to 'github_token' across all sub-actions in the monorepo to align with standard GitHub Actions conventions and avoid naming ambiguity.